### PR TITLE
Address6.fromArpa - take an ip6.arpa address and return Address…

### DIFF
--- a/lib/ipv6.js
+++ b/lib/ipv6.js
@@ -205,6 +205,41 @@ Address6.fromAddress4 = function (address4) {
   return new Address6('::ffff:' + address4);
 };
 
+/**
+ * Return an address from ip6.arpa form
+ * @memberof Address6
+ * @static
+ * @param {string} arpaFormAddress - an 'ip6.arpa' form address 
+ * @returns {Adress6}
+ * @example
+ * var address = Address6.fromArpa(e.f.f.f.3.c.2.6.f.f.f.e.6.6.8.e.1.0.6.7.9.4.e.c.0.0.0.0.1.0.0.2.ip6.arpa.)
+ * address.correctForm(); // '2001:0:ce49:7601:e866:efff:62c3:fffe'
+ */
+Address6.fromArpa = function (arpaFormAddress) {
+  //remove ending ".ip6.arpa." or just "."
+  var address = arpaFormAddress.replace(/(\.ip6\.arpa)?\.$/, '');
+  var semicolonAmount = 7;
+
+  //correct ip6.arpa form with ending removed will be 63 characters
+  if (address.length !== 63) {
+    address = {
+      error: "Not Valid 'ip6.arpa' form",
+      address: null
+    };
+    return address;
+  }
+
+  address = address.split('.').reverse();
+
+  for (var i = semicolonAmount; i > 0; i--) {
+    var insertIndex = i * 4;
+    address.splice(insertIndex, 0, ':');
+  }
+
+  address = address.join('');
+  return new Address6(address);
+};
+
 /*
  * A helper function to compact an array
  */

--- a/test/functionality-v6-test.js
+++ b/test/functionality-v6-test.js
@@ -340,6 +340,26 @@ describe('v6', function () {
     });
   });
 
+  describe('Address given in ap6.arpa form', function() {
+    var obj = Address6.fromArpa('e.f.f.f.3.c.2.6.f.f.f.e.6.6.8.e.1.0.6.7.9.4.e.c.0.0.0.0.1.0.0.2.ip6.arpa.');
+
+    it('should return an Address6 object', function() {
+      expect(obj instanceof Address6).to.equal(true);
+    });
+
+    it('should generate a valid v6 address', function() {
+      expect(obj.correctForm()).to.equal('2001:0:ce49:7601:e866:efff:62c3:fffe')
+    });
+
+    it('should fail with an invalid ip6.arpa length', function() {
+      var obj = Address6.fromArpa('e.f.f.f.3.c.2.6.f.f.f.e.6.6.8.0.6.7.9.4.e.c.0.0.0.0.1.0.0.2.ip6.arpa.');
+
+      expect(obj.error).to.equal("Not Valid 'ip6.arpa' form");
+      expect(obj.address).to.equal(null);
+    });
+  });
+
+
   describe('Address inside a URL or inside a URL with a port', function () {
     it('should work with a host address', function () {
       var obj = Address6.fromURL('2001:db8::5');


### PR DESCRIPTION
resolves #36

This creates the ability to create Address6 objects using an ip6.arpa format. 
