### PR TITLE
remove bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
     "docs": "documentation --github --output docs --format html ./ip-address.js",
     "prepublish": "browserify ./ip-address-globals.js > ./dist/ip-address-globals.js"
   },
-  "bin": {
-    "ipv6": "bin/ipv6.js",
-    "ipv6grep": "bin/ipv6grep.js"
-  },
   "engines": {
     "node": ">= 0.10"
   },


### PR DESCRIPTION
/bin was removed in 1015a81, but bin field in package.json was left in. As a result, installing 5.8.3 results in an error.