### PR TITLE
Add option for start and end address to exlude non-hosts

### DIFF
--- a/lib/ipv4.js
+++ b/lib/ipv4.js
@@ -184,6 +184,18 @@ Address4.prototype.bigInteger = function () {
 };
 
 /**
+ * Helper function getting start address.
+ * @memberof Address4
+ * @instance
+ * @returns {BigInteger}
+ */
+Address4.prototype._startAddress = function () {
+  return new BigInteger(
+    this.mask() + repeat(0, constants.BITS - this.subnetMask), 2
+  );
+};
+
+/**
  * The first address in the range given by this address' subnet.
  * Often referred to as the Network Address.
  * @memberof Address4
@@ -191,10 +203,31 @@ Address4.prototype.bigInteger = function () {
  * @returns {Address4}
  */
 Address4.prototype.startAddress = function () {
-  var startAddress = new BigInteger(this.mask() +
-    repeat(0, constants.BITS - this.subnetMask), 2);
+  return Address4.fromBigInteger(this._startAddress());
+};
 
-  return Address4.fromBigInteger(startAddress);
+/**
+ * The first host address in the range given by this address's subnet ie
+ * the first address after the Network Address
+ * @memberof Address4
+ * @instance
+ * @returns {Address4}
+ */
+Address4.prototype.startAddressExclusive = function () {
+    var adjust = new BigInteger('1');
+    return Address4.fromBigInteger(this._startAddress().add(adjust));
+};
+
+/**
+ * Helper function getting end address.
+ * @memberof Address4
+ * @instance
+ * @returns {BigInteger}
+ */
+Address4.prototype._endAddress = function () {
+    return new BigInteger(
+      this.mask() + repeat(1, constants.BITS - this.subnetMask), 2
+    );
 };
 
 /**
@@ -205,10 +238,19 @@ Address4.prototype.startAddress = function () {
  * @returns {Address4}
  */
 Address4.prototype.endAddress = function () {
-  var endAddress = new BigInteger(this.mask() +
-    repeat(1, constants.BITS - this.subnetMask), 2);
+  return Address4.fromBigInteger(this._endAddress());
+};
 
-  return Address4.fromBigInteger(endAddress);
+/**
+ * The last host address in the range given by this address's subnet ie
+ * the last address prior to the Broadcast Address
+ * @memberof Address4
+ * @instance
+ * @returns {Address4}
+ */
+Address4.prototype.endAddressExclusive = function () {
+    var adjust = new BigInteger('1');
+    return Address4.fromBigInteger(this._endAddress().subtract(adjust));
 };
 
 /**

--- a/lib/ipv6.js
+++ b/lib/ipv6.js
@@ -313,29 +313,73 @@ Address6.prototype.possibleSubnets = function (optionalSubnetSize) {
 };
 
 /**
+ * Helper function getting start address.
+ * @memberof Address6
+ * @instance
+ * @returns {BigInteger}
+ */
+Address6.prototype._startAddress = function () {
+  return new BigInteger(
+    this.mask() + repeat(0, constants6.BITS - this.subnetMask), 2
+  );
+};
+
+/**
  * The first address in the range given by this address' subnet
+ * Often referred to as the Network Address.
  * @memberof Address6
  * @instance
  * @returns {Address6}
  */
 Address6.prototype.startAddress = function () {
-  var startAddress = new BigInteger(this.mask() +
-    repeat(0, constants6.BITS - this.subnetMask), 2);
+  return Address6.fromBigInteger(this._startAddress());
+};
 
-  return Address6.fromBigInteger(startAddress);
+/**
+ * The first host address in the range given by this address's subnet ie
+ * the first address after the Network Address
+ * @memberof Address6
+ * @instance
+ * @returns {Address6}
+ */
+Address6.prototype.startAddressExclusive = function () {
+    var adjust = new BigInteger('1');
+    return Address6.fromBigInteger(this._startAddress().add(adjust));
+};
+
+/**
+ * Helper function getting end address.
+ * @memberof Address6
+ * @instance
+ * @returns {BigInteger}
+ */
+Address6.prototype._endAddress = function () {
+  return new BigInteger(
+      this.mask() + repeat(1, constants6.BITS - this.subnetMask), 2
+  );
 };
 
 /**
  * The last address in the range given by this address' subnet
+ * Often referred to as the Broadcast
  * @memberof Address6
  * @instance
  * @returns {Address6}
  */
 Address6.prototype.endAddress = function () {
-  var endAddress = new BigInteger(this.mask() +
-    repeat(1, constants6.BITS - this.subnetMask), 2);
+  return Address6.fromBigInteger(this._endAddress());
+};
 
-  return Address6.fromBigInteger(endAddress);
+/**
+ * The last host address in the range given by this address's subnet ie
+ * the last address prior to the Broadcast Address
+ * @memberof Address6
+ * @instance
+ * @returns {Address6}
+ */
+Address6.prototype.endAddressExclusive = function () {
+    var adjust = new BigInteger('1');
+    return Address6.fromBigInteger(this._endAddress().subtract(adjust));
 };
 
 /**

--- a/test/functionality-v4-test.js
+++ b/test/functionality-v4-test.js
@@ -117,8 +117,16 @@ describe('v4', function () {
       should.equal(topic.startAddress().correctForm(), '127.0.0.0');
     });
 
+    it('has a correct start address hosts only', function () {
+        should.equal(topic.startAddressExclusive().correctForm(), '127.0.0.1');
+    });
+
     it('has a correct end address', function () {
       should.equal(topic.endAddress().correctForm(), '127.0.255.255');
+    });
+
+    it('has a correct end address hosts only', function () {
+      should.equal(topic.endAddressExclusive().correctForm(), '127.0.255.254');
     });
 
     it('is in its own subnet', function () {

--- a/test/functionality-v6-test.js
+++ b/test/functionality-v6-test.js
@@ -150,9 +150,18 @@ describe('v6', function () {
       should.equal(topic.startAddress().correctForm(), 'ffff::');
     });
 
+    it('has a correct start address hosts only', function () {
+        should.equal(topic.startAddressExclusive().correctForm(), 'ffff::1');
+    });
+
     it('has a correct end address', function () {
       should.equal(topic.endAddress().correctForm(),
         'ffff::ffff:ffff:ffff:ffff');
+    });
+
+    it('has a correct end address hosts only', function () {
+        should.equal(topic.endAddressExclusive().correctForm(),
+                     'ffff::ffff:ffff:ffff:fffe');
     });
 
     it('calculates and formats the subnet size', function () {


### PR DESCRIPTION
Excludes network id and broadcast address from start address and end
address respectively.

Encountered a few situations were this would seem useful esp to client of this library like https://github.com/ortexx/ip-cidr