### PR TITLE
use specific lodash libraries rather than whole thing

### DIFF
--- a/lib/ipv4.js
+++ b/lib/ipv4.js
@@ -3,7 +3,8 @@
 var BigInteger = require('jsbn').BigInteger;
 var common = require('./common.js');
 var sprintf = require('sprintf-js').sprintf;
-var _ = require('lodash');
+var padStart = require('lodash.padstart');
+var repeat = require('lodash.repeat');
 
 var constants = require('./v4/constants.js');
 
@@ -97,7 +98,7 @@ Address4.prototype.isCorrect = common.isCorrect(constants.BITS);
  * @returns {Address4}
  */
 Address4.fromHex = function (hex) {
-  var padded = _.padStart(hex.replace(/:/g, ''), 8, '0');
+  var padded = padStart(hex.replace(/:/g, ''), 8, '0');
   var groups = [];
   var i;
 
@@ -190,7 +191,7 @@ Address4.prototype.bigInteger = function () {
  */
 Address4.prototype._startAddress = function () {
   return new BigInteger(
-    this.mask() + _.repeat('0', constants.BITS - this.subnetMask), 2
+    this.mask() + repeat('0', constants.BITS - this.subnetMask), 2
   );
 };
 
@@ -225,7 +226,7 @@ Address4.prototype.startAddressExclusive = function () {
  */
 Address4.prototype._endAddress = function () {
   return new BigInteger(
-    this.mask() + _.repeat('1', constants.BITS - this.subnetMask), 2
+    this.mask() + repeat('1', constants.BITS - this.subnetMask), 2
   );
 };
 
@@ -313,7 +314,7 @@ Address4.prototype.isMulticast = function () {
  * @returns {string}
  */
 Address4.prototype.binaryZeroPad = function () {
-  return _.padStart(this.bigInteger().toString(2), constants.BITS, '0');
+  return padStart(this.bigInteger().toString(2), constants.BITS, '0');
 };
 
 module.exports = Address4;

--- a/lib/ipv6.js
+++ b/lib/ipv6.js
@@ -2,7 +2,12 @@
 
 var BigInteger = require('jsbn').BigInteger;
 var sprintf = require('sprintf-js').sprintf;
-var _ = require('lodash');
+
+var merge = require('lodash.merge');
+var padStart = require('lodash.padstart');
+var repeat = require('lodash.repeat');
+var find = require('lodash.find');
+var max = require('lodash.max');
 
 var constants4 = require('./v4/constants.js');
 var constants6 = require('./v6/constants.js');
@@ -87,9 +92,9 @@ function Address6(address, optionalGroups) {
   this.parsedAddress = this.parse(this.addressMinusSuffix);
 }
 
-_.merge(Address6.prototype, require('./v6/attributes.js'));
-_.merge(Address6.prototype, require('./v6/html.js'));
-_.merge(Address6.prototype, require('./v6/regular-expressions.js'));
+merge(Address6.prototype, require('./v6/attributes.js'));
+merge(Address6.prototype, require('./v6/html.js'));
+merge(Address6.prototype, require('./v6/regular-expressions.js'));
 
 /**
  * Convert a BigInteger to a v6 address object
@@ -103,7 +108,7 @@ _.merge(Address6.prototype, require('./v6/regular-expressions.js'));
  * address.correctForm(); // '::e8:d4a5:1000'
  */
 Address6.fromBigInteger = function (bigInteger) {
-  var hex = _.padStart(bigInteger.toString(16), 32, '0');
+  var hex = padStart(bigInteger.toString(16), 32, '0');
   var groups = [];
   var i;
 
@@ -208,7 +213,7 @@ Address6.fromAddress4 = function (address4) {
  * Return an address from ip6.arpa form
  * @memberof Address6
  * @static
- * @param {string} arpaFormAddress - an 'ip6.arpa' form address 
+ * @param {string} arpaFormAddress - an 'ip6.arpa' form address
  * @returns {Adress6}
  * @example
  * var address = Address6.fromArpa(e.f.f.f.3.c.2.6.f.f.f.e.6.6.8.e.1.0.6.7.9.4.e.c.0.0.0.0.1.0.0.2.ip6.arpa.)
@@ -316,7 +321,7 @@ Address6.prototype.possibleSubnets = function (optionalSubnetSize) {
  */
 Address6.prototype._startAddress = function () {
   return new BigInteger(
-    this.mask() + _.repeat('0', constants6.BITS - this.subnetMask), 2
+    this.mask() + repeat('0', constants6.BITS - this.subnetMask), 2
   );
 };
 
@@ -351,7 +356,7 @@ Address6.prototype.startAddressExclusive = function () {
  */
 Address6.prototype._endAddress = function () {
   return new BigInteger(
-    this.mask() + _.repeat('1', constants6.BITS - this.subnetMask), 2
+    this.mask() + repeat('1', constants6.BITS - this.subnetMask), 2
   );
 };
 
@@ -408,7 +413,7 @@ Address6.prototype.getType = function () {
     return self.isInSubnet(new Address6(type));
   }
 
-  return _.find(constants6.TYPES, isType) || 'Global unicast';
+  return find(constants6.TYPES, isType) || 'Global unicast';
 };
 
 /**
@@ -444,7 +449,7 @@ Address6.prototype.getBitsBase16 = function (start, end) {
     return null;
   }
 
-  return _.padStart(this.getBits(start, end).toString(16), length / 4, '0');
+  return padStart(this.getBits(start, end).toString(16), length / 4, '0');
 };
 
 /**
@@ -538,7 +543,7 @@ Address6.prototype.correctForm = function () {
   });
 
   if (zeroes.length > 0) {
-    var index = zeroLengths.indexOf(_.max(zeroLengths));
+    var index = zeroLengths.indexOf(max(zeroLengths));
 
     groups = compact(this.parsedAddress, zeroes[index]);
   } else {
@@ -572,7 +577,7 @@ Address6.prototype.correctForm = function () {
  * //  0000000000000000000000000000000000000000000000000001000000010001'
  */
 Address6.prototype.binaryZeroPad = function () {
-  return _.padStart(this.bigInteger().toString(2), constants6.BITS, '0');
+  return padStart(this.bigInteger().toString(2), constants6.BITS, '0');
 };
 
 // TODO: Improve the semantics of this helper function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1611,7 +1611,6 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
-      "optional": true,
       "requires": {
         "hoek": "0.9.x"
       }
@@ -3460,8 +3459,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3482,14 +3480,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3504,20 +3500,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3634,8 +3627,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3647,7 +3639,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3662,7 +3653,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3670,14 +3660,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3696,7 +3684,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3777,8 +3764,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3790,7 +3776,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3876,8 +3861,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3913,7 +3897,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3933,7 +3916,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3977,14 +3959,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4330,8 +4310,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -5019,13 +4998,39 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+    },
+    "lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
     },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
+    },
+    "lodash.repeat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
+      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,11 @@
   },
   "dependencies": {
     "jsbn": "1.1.0",
-    "lodash": "^4.17.15",
+    "lodash.find": "4.6.0",
+    "lodash.max": "4.0.1",
+    "lodash.merge": "4.6.2",
+    "lodash.padstart": "4.6.1",
+    "lodash.repeat": "4.1.0",
     "sprintf-js": "1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
👋 

Also having the problem [reported here](https://github.com/beaugunderson/ip-address/issues/89). Quick fix here replaces the monolith with a few smaller libraries pulled out of the original.

The lodash versions are often still decent in size as they have to accommodate a somewhat expansive API. May be good in some cases to replace those with smaller libraries with smaller APIs or potentially yank some code in from somewhere. I'm reluctant to do any replacing as I am unsure what sorts of cases other than the obvious that calls like `max` and `padStart` require.