### PR TITLE
perf: smaller browser bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,5 @@ node_js:
   - 10
   - 9
   - 8
-  - 7
-  - 6
 script: "./coverage.sh"
 sudo: false

--- a/lib/ipv4.js
+++ b/lib/ipv4.js
@@ -3,8 +3,6 @@
 var BigInteger = require('jsbn').BigInteger;
 var common = require('./common.js');
 var sprintf = require('sprintf-js').sprintf;
-var padStart = require('lodash.padstart');
-var repeat = require('lodash.repeat');
 
 var constants = require('./v4/constants.js');
 
@@ -98,7 +96,7 @@ Address4.prototype.isCorrect = common.isCorrect(constants.BITS);
  * @returns {Address4}
  */
 Address4.fromHex = function (hex) {
-  var padded = padStart(hex.replace(/:/g, ''), 8, '0');
+  var padded = hex.replace(/:/g, '').padStart(8, '0');
   var groups = [];
   var i;
 
@@ -191,7 +189,7 @@ Address4.prototype.bigInteger = function () {
  */
 Address4.prototype._startAddress = function () {
   return new BigInteger(
-    this.mask() + repeat('0', constants.BITS - this.subnetMask), 2
+    this.mask() + '0'.repeat(constants.BITS - this.subnetMask), 2
   );
 };
 
@@ -226,7 +224,7 @@ Address4.prototype.startAddressExclusive = function () {
  */
 Address4.prototype._endAddress = function () {
   return new BigInteger(
-    this.mask() + repeat('1', constants.BITS - this.subnetMask), 2
+    this.mask() + '1'.repeat(constants.BITS - this.subnetMask), 2
   );
 };
 
@@ -314,7 +312,7 @@ Address4.prototype.isMulticast = function () {
  * @returns {string}
  */
 Address4.prototype.binaryZeroPad = function () {
-  return padStart(this.bigInteger().toString(2), constants.BITS, '0');
+  return this.bigInteger().toString(2).padStart(constants.BITS, '0');
 };
 
 module.exports = Address4;

--- a/lib/ipv6.js
+++ b/lib/ipv6.js
@@ -539,7 +539,7 @@ Address6.prototype.correctForm = function () {
   });
 
   if (zeroes.length > 0) {
-    var index = zeroLengths.indexOf(Math.max.apply(Math, zeroLengths));
+    var index = zeroLengths.indexOf(Math.max(...zeroLengths));
 
     groups = compact(this.parsedAddress, zeroes[index]);
   } else {

--- a/lib/ipv6.js
+++ b/lib/ipv6.js
@@ -3,12 +3,6 @@
 var BigInteger = require('jsbn').BigInteger;
 var sprintf = require('sprintf-js').sprintf;
 
-var merge = require('lodash.merge');
-var padStart = require('lodash.padstart');
-var repeat = require('lodash.repeat');
-var find = require('lodash.find');
-var max = require('lodash.max');
-
 var constants4 = require('./v4/constants.js');
 var constants6 = require('./v6/constants.js');
 
@@ -92,9 +86,9 @@ function Address6(address, optionalGroups) {
   this.parsedAddress = this.parse(this.addressMinusSuffix);
 }
 
-merge(Address6.prototype, require('./v6/attributes.js'));
-merge(Address6.prototype, require('./v6/html.js'));
-merge(Address6.prototype, require('./v6/regular-expressions.js'));
+Object.assign(Address6.prototype, require('./v6/attributes.js'));
+Object.assign(Address6.prototype, require('./v6/html.js'));
+Object.assign(Address6.prototype, require('./v6/regular-expressions.js'));
 
 /**
  * Convert a BigInteger to a v6 address object
@@ -108,7 +102,7 @@ merge(Address6.prototype, require('./v6/regular-expressions.js'));
  * address.correctForm(); // '::e8:d4a5:1000'
  */
 Address6.fromBigInteger = function (bigInteger) {
-  var hex = padStart(bigInteger.toString(16), 32, '0');
+  var hex = bigInteger.toString(16).padStart(32, '0');
   var groups = [];
   var i;
 
@@ -321,7 +315,7 @@ Address6.prototype.possibleSubnets = function (optionalSubnetSize) {
  */
 Address6.prototype._startAddress = function () {
   return new BigInteger(
-    this.mask() + repeat('0', constants6.BITS - this.subnetMask), 2
+    this.mask() + '0'.repeat(constants6.BITS - this.subnetMask), 2
   );
 };
 
@@ -356,7 +350,7 @@ Address6.prototype.startAddressExclusive = function () {
  */
 Address6.prototype._endAddress = function () {
   return new BigInteger(
-    this.mask() + repeat('1', constants6.BITS - this.subnetMask), 2
+    this.mask() + '1'.repeat(constants6.BITS - this.subnetMask), 2
   );
 };
 
@@ -409,11 +403,13 @@ Address6.prototype.getScope = function () {
 Address6.prototype.getType = function () {
   var self = this;
 
-  function isType(name, type) {
-    return self.isInSubnet(new Address6(type));
+  function isType(entry) {
+    return self.isInSubnet(new Address6(entry[0]));
   }
 
-  return find(constants6.TYPES, isType) || 'Global unicast';
+  var entry = Object.entries(constants6.TYPES).find(isType);
+
+  return entry ? entry[1] : 'Global unicast';
 };
 
 /**
@@ -449,7 +445,7 @@ Address6.prototype.getBitsBase16 = function (start, end) {
     return null;
   }
 
-  return padStart(this.getBits(start, end).toString(16), length / 4, '0');
+  return this.getBits(start, end).toString(16).padStart(length / 4, '0');
 };
 
 /**
@@ -543,7 +539,7 @@ Address6.prototype.correctForm = function () {
   });
 
   if (zeroes.length > 0) {
-    var index = zeroLengths.indexOf(max(zeroLengths));
+    var index = zeroLengths.indexOf(Math.max.apply(Math, zeroLengths));
 
     groups = compact(this.parsedAddress, zeroes[index]);
   } else {
@@ -577,7 +573,7 @@ Address6.prototype.correctForm = function () {
  * //  0000000000000000000000000000000000000000000000000001000000010001'
  */
 Address6.prototype.binaryZeroPad = function () {
-  return padStart(this.bigInteger().toString(2), constants6.BITS, '0');
+  return this.bigInteger().toString(2).padStart(constants6.BITS, '0');
 };
 
 // TODO: Improve the semantics of this helper function

--- a/package-lock.json
+++ b/package-lock.json
@@ -5022,36 +5022,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
-    "lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
-    },
-    "lodash.max": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
-      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
-    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
-    },
-    "lodash.repeat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
-      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
     },
     "log-symbols": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs": "documentation build --github --output docs --format html ./ip-address.js"
   },
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 8.0.0"
   },
   "files": [
     "ip-address.js",
@@ -29,11 +29,6 @@
   },
   "dependencies": {
     "jsbn": "1.1.0",
-    "lodash.find": "4.6.0",
-    "lodash.max": "4.0.1",
-    "lodash.merge": "4.6.2",
-    "lodash.padstart": "4.6.1",
-    "lodash.repeat": "4.1.0",
     "sprintf-js": "1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This removes lodash for a significantly smaller bundle in the browser. From https://bundlephobia.com/result?p=ip-address@6.2.0 you can see that lodash is a significant portion of the bundle size.

The functions that were delegated to lodash are supported in native javascript by the majority of runtimes.

BREAKING CHANGE: Removes support for IE11, Android webview and Node.js < 8.0.0