### PR TITLE
Correct Address6.to4() return type

### DIFF
--- a/lib/ipv6.js
+++ b/lib/ipv6.js
@@ -767,10 +767,10 @@ Address6.prototype.bigInteger = function () {
  * Return the last two groups of this address as an IPv4 address string
  * @memberof Address6
  * @instance
- * @returns {String}
+ * @returns {Address4}
  * @example
  * var address = new Address6('2001:4860:4001::1825:bf11');
- * address.to4(); // '24.37.191.17'
+ * address.to4().correctForm(); // '24.37.191.17'
  */
 Address6.prototype.to4 = function () {
   var binary = this.binaryZeroPad().split('');


### PR DESCRIPTION
Update JSDoc return type of `Address6.to4()` to `Address4`

Fixes #93
Fixes #77 