### PR TITLE
Travis-ci: added ppc64le support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+   - amd64
+   - ppc64le
 addons:
   apt:
     sources:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/ip-address/builds/206989623 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!