### PR TITLE
Export AddressError

### DIFF
--- a/ip-address.ts
+++ b/ip-address.ts
@@ -1,8 +1,10 @@
 import { Address4 } from './lib/ipv4';
 import { Address6 } from './lib/ipv6';
+import { AddressError } from "./lib/address-error';
 
 export { Address4 };
 export { Address6 };
+export { AddressError };
 
 import * as helpers from './lib/v6/helpers';
 

--- a/ip-address.ts
+++ b/ip-address.ts
@@ -1,6 +1,6 @@
 import { Address4 } from './lib/ipv4';
 import { Address6 } from './lib/ipv6';
-import { AddressError } from "./lib/address-error';
+import { AddressError } from './lib/address-error';
 
 export { Address4 };
 export { Address6 };


### PR DESCRIPTION
Currently AddressError is not exported, meaning that package consumers can't easily use it