### PR TITLE
Simplified PR for esm and cjs builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "types": "dist/mjs/ip-address.d.ts",
   "scripts": {
     "docs": "documentation build --github --output docs --format html ./ip-address.js",
-    "prepublishOnly": "tsc --build tsconfig-cjs.json && tsc --build tsconfig-esm.json",
+    "prepublishOnly": "tsc --build tsconfig-cjs.json && tsc --build tsconfig-esm.json && npm run _postTSC",
+    "_postTSC": "echo '{\"type\": \"module\"}' >dist/mjs/package.json && echo '{\"type\": \"commonjs\"}' >dist/cjs/package.json",
     "release": "release-it",
     "test-ci": "TS_NODE_PROJECT=./tsconfig-cjs.json  nyc mocha",
     "test": "TS_NODE_PROJECT=./tsconfig-cjs.json  mocha",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "require": "./dist/cjs/ip-address.js"
     }
   },
-  "types": "dist/ip-address.d.ts",
+  "types": "dist/mjs/ip-address.d.ts",
   "scripts": {
     "docs": "documentation build --github --output docs --format html ./ip-address.js",
     "prepublishOnly": "tsc --build tsconfig-cjs.json && tsc --build tsconfig-esm.json",

--- a/package.json
+++ b/package.json
@@ -10,15 +10,22 @@
   "version": "7.1.0",
   "author": "Beau Gunderson <beau@beaugunderson.com> (https://beaugunderson.com/)",
   "license": "MIT",
-  "main": "dist/ip-address.js",
+  "main": "dist/cjs/ip-address.js",
+  "module": "dist/mjs/ip-address.js",
+  "exports": {
+    ".": {
+      "import": "./dist/mjs/ip-address.js",
+      "require": "./dist/cjs/ip-address.js"
+    }
+  },
   "types": "dist/ip-address.d.ts",
   "scripts": {
     "docs": "documentation build --github --output docs --format html ./ip-address.js",
-    "prepublishOnly": "tsc",
+    "prepublishOnly": "tsc --build tsconfig-cjs.json && tsc --build tsconfig-esm.json",
     "release": "release-it",
-    "test-ci": "nyc mocha",
-    "test": "mocha",
-    "watch": "mocha --watch"
+    "test-ci": "TS_NODE_PROJECT=./tsconfig-cjs.json  nyc mocha",
+    "test": "TS_NODE_PROJECT=./tsconfig-cjs.json  mocha",
+    "watch": "TS_NODE_PROJECT=./tsconfig-cjs.json  mocha --watch"
   },
   "nyc": {
     "extension": [

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
     "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     "outDir": "dist",                        /* Redirect output structure to the directory. */
     "resolveJsonModule": true,
     "sourceMap": true,
+
+    "moduleResolution": "node",            /* resolveJsonModule cannot be specified without this (this effectively just means node_modules will be searched;  See tsconfig docs  */
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
@@ -25,7 +25,7 @@
     "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+	  "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
 
     /* Advanced Options */
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig-base.json",
+	"compilerOptions": {
+		"target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig-base.json",
+	"compilerOptions": {
+		"target": "es2015",
+		"module": "es2015",
+		"outDir": "dist/mjs"
+	}
+}


### PR DESCRIPTION
This is an alternative PR to #120 
My goal was the minimal number of changes that would produce `esm` and `cjs` builds.

Basically, `tsc` is just run twice, with two different tsconfig files.

This article was used as a general guide (no affiliation):
[How to Create a Hybrid NPM Module for ESM and CommonJS](https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html)

Both `npm test` and `npm run test-ci` still run successfully.
I also built `ip-address` locally, and ran it against my current project using `npm link`, and all my tests still pass :star:

To summarize this PR...
I renamed the root tsconfig file to tsconfig-base and then added a tsconfig file for esm and another for cjs.  
The new configs inherit from tsconfig-base and only contain module related overrides.
`package.json` was changed to ensure the correct tsconfig is called, and the new entry points were indicated for cjs vs esm.

FWIW, I worked through these changes for two of my own GitHub projects ([pcafstockf/async-injection](https://github.com/pcafstockf/async-injection) and [pcafstockf/pfta](https://github.com/pcafstockf/pfta)) before starting this PR, and am happy with the results so far.


I used to get warnings from the Angular compiler:
```
Warning: /src/validations.ts depends on 'ip-address'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies

// Repeated for my own two GitHub projects
```
**All 3 of those warnings are now gone.**


### Caveat
Now I get:
`Warning: node_modules/ip-address/dist/mjs/lib/ipv4.js depends on 'sprintf-js'. CommonJS or AMD dependencies can cause optimization bailouts.
`

But that's a problem for another day.  Maybe I'll submit a PR to sprintf-js folks when I have a little more time.
:smiley:
