### PR TITLE
fix: remove unnecessary optional type on `addressMinusSuffix` for `Address4`

### DIFF
--- a/lib/ipv4.ts
+++ b/lib/ipv4.ts
@@ -13,7 +13,7 @@ import { sprintf } from 'sprintf-js';
  */
 export class Address4 {
   address: string;
-  addressMinusSuffix?: string;
+  addressMinusSuffix: string;
   groups: number = constants.GROUPS;
   parsedAddress: string[] = [];
   parsedSubnet: string = '';


### PR DESCRIPTION
Fixes #143 