### PR TITLE
Replace `jsbn` with native BigInt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "ip-address",
       "version": "9.1.0-0",
       "license": "MIT",
-      "dependencies": {
-        "@types/jsbn": "^1.2.33",
-        "jsbn": "1.1.0"
-      },
       "devDependencies": {
         "@types/chai": "^5.0.0",
         "@types/mocha": "^10.0.8",
@@ -1469,12 +1465,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz",
       "integrity": "sha512-FD+nQWA2zJjh4L9+pFXqWOi0Hs1ryBCfI+985NjluQ1p8EYtoLvjLOKidXBtZ4/IcxDX4o8/E8qDS3540tNliw==",
       "dev": true
-    },
-    "node_modules/@types/jsbn": {
-      "version": "1.2.33",
-      "resolved": "https://registry.npmjs.org/@types/jsbn/-/jsbn-1.2.33.tgz",
-      "integrity": "sha512-ZlLkHfu8xqqVFSbCe1FSPtAMUs7LKxk7TPskMb+sI5IbuzqyVqIEt9SVaQfFD2vrFcQunqKAmEBOuBEkoNLw4g==",
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -7238,7 +7228,8 @@
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
     },
     "node_modules/jsesc": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -51,10 +51,6 @@
     "type": "git",
     "url": "git://github.com/beaugunderson/ip-address.git"
   },
-  "dependencies": {
-    "@types/jsbn": "^1.2.33",
-    "jsbn": "1.1.0"
-  },
   "devDependencies": {
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.8",

--- a/src/common.ts
+++ b/src/common.ts
@@ -38,3 +38,18 @@ export function numberToPaddedHex(number: number) {
 export function stringToPaddedHex(numberString: string) {
   return numberToPaddedHex(parseInt(numberString, 10));
 }
+
+/**
+ * @param binaryValue Binary representation of a value (e.g. `10`)
+ * @param position Byte position, where 0 is the least significant bit
+ */
+export function testBit(binaryValue: string, position: number): boolean {
+  const { length } = binaryValue;
+
+  if (position > length) {
+    return false;
+  }
+
+  const positionInString = length - position;
+  return binaryValue.substring(positionInString, positionInString + 1) === '1';
+}

--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -3,7 +3,6 @@
 import * as common from './common';
 import * as constants from './v4/constants';
 import { AddressError } from './address-error';
-import { BigInteger } from 'jsbn';
 
 /**
  * Represents an IPv4 address
@@ -177,23 +176,23 @@ export class Address4 {
   }
 
   /**
-   * Returns the address as a BigInteger
+   * Returns the address as a `bigint`
    * @memberof Address4
    * @instance
-   * @returns {BigInteger}
+   * @returns {bigint}
    */
-  bigInteger(): BigInteger {
-    return new BigInteger(this.parsedAddress.map((n) => common.stringToPaddedHex(n)).join(''), 16);
+  bigInteger(): BigInt {
+    return BigInt(`0x${this.parsedAddress.map((n) => common.stringToPaddedHex(n)).join('')}`);
   }
 
   /**
    * Helper function getting start address.
    * @memberof Address4
    * @instance
-   * @returns {BigInteger}
+   * @returns {bigint}
    */
-  _startAddress(): BigInteger {
-    return new BigInteger(this.mask() + '0'.repeat(constants.BITS - this.subnetMask), 2);
+  _startAddress(): bigint {
+    return BigInt(`0b${this.mask() + '0'.repeat(constants.BITS - this.subnetMask)}`);
   }
 
   /**
@@ -215,18 +214,18 @@ export class Address4 {
    * @returns {Address4}
    */
   startAddressExclusive(): Address4 {
-    const adjust = new BigInteger('1');
-    return Address4.fromBigInteger(this._startAddress().add(adjust));
+    const adjust = BigInt('1');
+    return Address4.fromBigInteger(this._startAddress() + adjust);
   }
 
   /**
    * Helper function getting end address.
    * @memberof Address4
    * @instance
-   * @returns {BigInteger}
+   * @returns {bigint}
    */
-  _endAddress(): BigInteger {
-    return new BigInteger(this.mask() + '1'.repeat(constants.BITS - this.subnetMask), 2);
+  _endAddress(): bigint {
+    return BigInt(`0b${this.mask() + '1'.repeat(constants.BITS - this.subnetMask)}`);
   }
 
   /**
@@ -248,19 +247,19 @@ export class Address4 {
    * @returns {Address4}
    */
   endAddressExclusive(): Address4 {
-    const adjust = new BigInteger('1');
-    return Address4.fromBigInteger(this._endAddress().subtract(adjust));
+    const adjust = BigInt('1');
+    return Address4.fromBigInteger(this._endAddress() - adjust);
   }
 
   /**
    * Converts a BigInteger to a v4 address object
    * @memberof Address4
    * @static
-   * @param {BigInteger} bigInteger - a BigInteger to convert
+   * @param {bigint} bigInteger - a BigInteger to convert
    * @returns {Address4}
    */
-  static fromBigInteger(bigInteger: BigInteger): Address4 {
-    return Address4.fromInteger(parseInt(bigInteger.toString(), 10));
+  static fromBigInteger(bigInteger: bigint): Address4 {
+    return Address4.fromHex(bigInteger.toString(16));
   }
 
   /**

--- a/test/common-test.ts
+++ b/test/common-test.ts
@@ -1,0 +1,18 @@
+import * as chai from 'chai';
+import { testBit } from '../src/common';
+
+const should = chai.should();
+
+describe('testBit', () => {
+  it('should return value per specific bit', () => {
+    should.equal(testBit('0', 1), false);
+    should.equal(testBit('1', 1), true);
+
+    should.equal(testBit('1010', 1), false);
+    should.equal(testBit('1010', 2), true);
+    should.equal(testBit('1010', 3), false);
+    should.equal(testBit('1010', 4), true);
+    // Length bigger than the size of string
+    should.equal(testBit('1010', 5), false);
+  });
+});

--- a/test/functionality-v4-test.ts
+++ b/test/functionality-v4-test.ts
@@ -1,6 +1,5 @@
 import * as chai from 'chai';
 import { Address4 } from '../src/ipv4';
-import { BigInteger } from 'jsbn';
 
 const should = chai.should();
 
@@ -125,7 +124,7 @@ describe('v4', () => {
   });
 
   describe('Creating an address from a BigInteger', () => {
-    const topic = Address4.fromBigInteger(new BigInteger('2130706433'));
+    const topic = Address4.fromBigInteger(BigInt('2130706433'));
 
     it('should parse correctly', () => {
       topic.correctForm().should.equal('127.0.0.1');
@@ -136,7 +135,7 @@ describe('v4', () => {
     const topic = new Address4('127.0.0.1');
 
     it('should convert properly', () => {
-      topic.bigInteger().intValue().should.equal(2130706433);
+      topic.bigInteger().toString(10).should.equal('2130706433');
     });
   });
 

--- a/test/functionality-v6-test.ts
+++ b/test/functionality-v6-test.ts
@@ -238,6 +238,12 @@ describe('v6', () => {
       should.equal(teredo.flags, '1110100001100110');
       should.equal(teredo.udpPort, '4096');
       should.equal(teredo.client4, '157.60.0.1');
+      should.equal(teredo.coneNat, true);
+
+      should.equal(teredo.microsoft.reserved, true);
+      should.equal(teredo.microsoft.universalLocal, false);
+      should.equal(teredo.microsoft.groupIndividual, false);
+      should.equal(teredo.microsoft.nonce, '2662');
     });
   });
 

--- a/test/functionality-v6-test.ts
+++ b/test/functionality-v6-test.ts
@@ -1,6 +1,5 @@
 import * as chai from 'chai';
 import { Address6 } from '../src/ipv6';
-import { BigInteger } from 'jsbn';
 import { v6 } from '../src/ip-address';
 
 const { expect } = chai;
@@ -414,7 +413,7 @@ describe('v6', () => {
   });
 
   describe('An address from a BigInteger', () => {
-    const topic = Address6.fromBigInteger(new BigInteger('51923840109643282840007714694758401'));
+    const topic = Address6.fromBigInteger(BigInt('51923840109643282840007714694758401'));
 
     it('should parse correctly', () => {
       should.equal(topic.correctForm(), 'a:b:c:d:e:f:0:1');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2016",
     "module": "commonjs",
     "allowJs": true,
     "declaration": true,
@@ -29,7 +29,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
 
-    "lib": ["es2017"]
+    "lib": ["es2020"]
   },
 
   "include": [


### PR DESCRIPTION
This PR follows up on #173 and fixes #169 for good by switching from `jsbn` `BigInteger` instance to native `BigInt`.

This PR introduces breaking changes:
* API: Methods that accepted `BigInteger` and returned `BigInteger` work with `bigint` right now
* TypeScript compilation target was bumped (due to need of `bigint`)

If you find this valuable, it might need:
* Documenting bump TypeScript compilation target
* Documenting API breaking changes
* Release of major version of the library

Let me know, @beaugunderson what you think about this PR.