### PR TITLE
Fix Address4.bigInt return type

### DIFF
--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -181,7 +181,7 @@ export class Address4 {
    * @instance
    * @returns {bigint}
    */
-  bigInt(): BigInt {
+  bigInt(): bigint {
     return BigInt(`0x${this.parsedAddress.map((n) => common.stringToPaddedHex(n)).join('')}`);
   }
 


### PR DESCRIPTION
Love the removal of jsbn, thank you!

Was converting my code but had an issue where I kept getting `ts: Operator '+' cannot be applied to types 'BigInt' and 'bigint'.` errors. Appeared the return type was accidentally statically set to `BigInt` the function not `bigint` the primitive type.