### PR TITLE
fix: correctly identify v4-mapped addresses in hex format (#62)

### DIFF
--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -149,6 +149,13 @@ export class Address6 {
     this.addressMinusSuffix = address;
 
     this.parsedAddress = this.parse(this.addressMinusSuffix);
+    if (
+      this.parsedAddress.length === 8 &&
+      this.parsedAddress.slice(0, 5).every((group) => group === '0') &&
+      this.parsedAddress[5].toLowerCase() === 'ffff'
+    ) {
+      this.v4 = true;
+    }
   }
 
   static isValid(address: string): boolean {

--- a/test/issue-62-test.ts
+++ b/test/issue-62-test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { Address6 } from '../src/ipv6';
+
+describe('Issue #62', () => {
+  it('should recognize v4-mapped addresses in hex format', () => {
+    const addr = new Address6('::ffff:7f00:1');
+    expect(addr.v4).to.equal(true);
+  });
+
+  it('should still recognize v4-mapped addresses in dotted decimal format', () => {
+    const addr = new Address6('::ffff:127.0.0.1');
+    expect(addr.v4).to.equal(true);
+  });
+
+  it('should not recognize other addresses as v4-mapped', () => {
+    const addr = new Address6('2001:db8::1');
+    expect(addr.v4).to.equal(false);
+  });
+});


### PR DESCRIPTION
This PR fixes Issue #62, where IPv4-mapped IPv6 addresses (::ffff:0:0/96) were not correctly identified as such when provided in hexadecimal format (e.g., `::ffff:7f00:1`).

### Changes
- Updated the `Address6` constructor to detect v4-mapped patterns in the parsed address array.
- Added a new test suite `test/issue-62-test.ts` with reproduction cases for both hex and dotted decimal formats.

### Validation
- Verified that the new tests fail without the fix and pass with it.
- All 2018 existing tests passed.

Fixes #62