### PR TITLE
Add Address4.subnetMaskAddress()

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ Represents an IPv4 address
 - `static fromHex(hex: string): Address4` — Converts a hex string to an IPv4 address object [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L97)
 - `static fromInteger(integer: number): Address4` — Converts an integer into a IPv4 address object [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L116)
 - `static fromArpa(arpaFormAddress: string): Address4` — Return an address from in-addr.arpa form [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L128)
-- `static fromBigInt(bigInt: bigint): Address4` — Converts a BigInt to a v4 address object [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L239)
-- `static fromByteArray(bytes: number[]): Address4` — Convert a byte array to an Address4 object [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L248)
-- `static fromUnsignedByteArray(bytes: number[]): Address4` — Convert an unsigned byte array to an Address4 object [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L268)
+- `static fromBigInt(bigInt: bigint): Address4` — Converts a BigInt to a v4 address object [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L250)
+- `static fromByteArray(bytes: number[]): Address4` — Convert a byte array to an Address4 object [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L259)
+- `static fromUnsignedByteArray(bytes: number[]): Address4` — Convert an unsigned byte array to an Address4 object [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L279)
 
 **Instance methods**
 
@@ -128,12 +128,13 @@ Represents an IPv4 address
 - `startAddressExclusive(): Address4` — The first host address in the range given by this address's subnet ie the first address after the Network Address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L202)
 - `endAddress(): Address4` — The last address in the range given by this address' subnet Often referred to as the Broadcast [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L220)
 - `endAddressExclusive(): Address4` — The last host address in the range given by this address's subnet ie the last address prior to the Broadcast Address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L229)
-- `mask(mask?: number): string` — Returns the first n bits of the address, defaulting to the subnet mask [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L282)
-- `getBitsBase2(start: number, end: number): string` — Returns the bits in the given range as a base-2 string [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L294)
-- `reverseForm(options?: ReverseFormOptions): string` — Return the reversed ip6.arpa form of the address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L304)
-- `isMulticast(): boolean` — Returns true if the given address is a multicast address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L328)
-- `binaryZeroPad(): string` — Returns a zero-padded base-2 string representation of the address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L336)
-- `groupForV6(): string` — Groups an IPv4 address for inclusion at the end of an IPv6 address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L347)
+- `subnetMaskAddress(): Address4` — The dotted-decimal form of the subnet mask, e.g. `255.255.240.0` for a `/20`. Returns an `Address4`; call `.correctForm()` for the string. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L239)
+- `mask(mask?: number): string` — Returns the first n bits of the address, defaulting to the subnet mask [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L293)
+- `getBitsBase2(start: number, end: number): string` — Returns the bits in the given range as a base-2 string [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L305)
+- `reverseForm(options?: ReverseFormOptions): string` — Return the reversed ip6.arpa form of the address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L315)
+- `isMulticast(): boolean` — Returns true if the given address is a multicast address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L339)
+- `binaryZeroPad(): string` — Returns a zero-padded base-2 string representation of the address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L347)
+- `groupForV6(): string` — Groups an IPv4 address for inclusion at the end of an IPv6 address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L358)
 
 **Properties**
 
@@ -146,7 +147,7 @@ Represents an IPv4 address
 - `subnetMask: number` — [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L20)
 - `v4: boolean` — [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L21)
 - `isCorrect: (this: Address4 | Address6) => boolean` — Returns true if the address is correct, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L90)
-- `isInSubnet: (this: Address4 | Address6, address: Address4 | Address6) => boolean` — Returns true if the given address is in the subnet of the current address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L322)
+- `isInSubnet: (this: Address4 | Address6, address: Address4 | Address6) => boolean` — Returns true if the given address is in the subnet of the current address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L333)
 
 #### Address6
 

--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -232,6 +232,17 @@ export class Address4 {
   }
 
   /**
+   * The dotted-decimal form of the subnet mask, e.g. `255.255.240.0` for
+   * a `/20`. Returns an `Address4`; call `.correctForm()` for the string.
+   * @returns {Address4}
+   */
+  subnetMaskAddress(): Address4 {
+    return Address4.fromBigInt(
+      BigInt(`0b${'1'.repeat(this.subnetMask)}${'0'.repeat(constants.BITS - this.subnetMask)}`),
+    );
+  }
+
+  /**
    * Converts a BigInt to a v4 address object
    * @param {bigint} bigInt - a BigInt to convert
    * @returns {Address4}

--- a/test/functionality-v4-test.ts
+++ b/test/functionality-v4-test.ts
@@ -114,12 +114,40 @@ describe('v4', () => {
       should.equal(topic.endAddressExclusive().correctForm(), '127.0.255.254');
     });
 
+    it('has a correct subnet mask address', () => {
+      should.equal(topic.subnetMaskAddress().correctForm(), '255.255.0.0');
+    });
+
     it('is in its own subnet', () => {
       topic.isInSubnet(new Address4('127.0.0.1/16')).should.equal(true);
     });
 
     it('is not in another subnet', () => {
       topic.isInSubnet(new Address4('192.168.0.1/16')).should.equal(false);
+    });
+  });
+
+  describe('subnetMaskAddress', () => {
+    it('returns 0.0.0.0 for /0', () => {
+      should.equal(new Address4('0.0.0.0/0').subnetMaskAddress().correctForm(), '0.0.0.0');
+    });
+
+    it('returns 255.0.0.0 for /8', () => {
+      should.equal(new Address4('10.0.0.1/8').subnetMaskAddress().correctForm(), '255.0.0.0');
+    });
+
+    it('returns 255.255.240.0 for /20', () => {
+      should.equal(
+        new Address4('127.0.0.2/20').subnetMaskAddress().correctForm(),
+        '255.255.240.0',
+      );
+    });
+
+    it('returns 255.255.255.255 for /32 (default)', () => {
+      should.equal(
+        new Address4('192.168.1.1').subnetMaskAddress().correctForm(),
+        '255.255.255.255',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `Address4.subnetMaskAddress(): Address4`, returning the dotted-decimal form of the subnet mask (`127.0.0.2/20` → `255.255.240.0`)
- Returning an `Address4` (rather than a raw string) matches the existing `startAddress` / `endAddress` style, pairs naturally with the `subnetMask: number` prefix-length property, and lets callers chain `.correctForm()`, `.toHex()`, `.bigInt()`, etc.
- Implementation reuses `Address4.fromBigInt` and the same binary-string idiom as `_startAddress` / `_endAddress`, so no new bit-twiddling utility is introduced
- Inspired by [#95](https://github.com/beaugunderson/ip-address/pull/95) (which targeted the old JS code, returned a string, and never landed)

## Test plan

- [x] `npm test` — 2029 passing (was 2024); 5 new cases cover `/0`, `/8`, `/16`, `/20`, and the default `/32`
- [x] `npm run test-ci` — 100% coverage maintained
- [x] `npm run build` — clean
- [x] `npm run docs` — README regenerated; new method appears under `Address4` instance methods