### PR TITLE
Ignore .claude/ (local agent state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ coverage/
 docs/
 dist/
 .nyc_output/
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so local Claude Code state (`settings.local.json`, `worktrees/`) doesn't show up as untracked when running `gh pr create` etc.