### PR TITLE
add NAT64 IPv4/IPv6 conversion (RFC 6052)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ Represents an IPv6 address
 - `static fromAddressAndMask(address: string, mask: string): Address6` — Construct an `Address6` from an address and a hex subnet mask given as separate strings (e.g. as returned by Node's `os.networkInterfaces()`). Throws `AddressError` if the mask is non-contiguous (e.g. `ffff::ffff`). [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L271)
 - `static fromAddress4(address: string): Address6` — Create an IPv6-mapped address given an IPv4 address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L285)
 - `static fromArpa(arpaFormAddress: string): Address6` — Return an address from ip6.arpa form [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L301)
-- `static fromByteArray(bytes: any[]): Address6` — Convert a byte array to an Address6 object. To convert from a Node.js `Buffer`, spread it: `Address6.fromByteArray([...buf])`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L929)
-- `static fromUnsignedByteArray(bytes: any[]): Address6` — Convert an unsigned byte array to an Address6 object. To convert from a Node.js `Buffer`, spread it: `Address6.fromUnsignedByteArray([...buf])`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L939)
+- `static fromAddress4Nat64(address: string, prefix: string): Address6` — Embed an IPv4 address into a NAT64 IPv6 address using the encoding defined by [RFC 6052](https://datatracker.ietf.org/doc/html/rfc6052). The default prefix is the well-known prefix `64:ff9b::/96`. The prefix length must be one of 32, 40, 48, 56, 64, or 96; for prefixes shorter than /64 the IPv4 octets are split around the reserved bits 64–71. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L903)
+- `static fromByteArray(bytes: any[]): Address6` — Convert a byte array to an Address6 object. To convert from a Node.js `Buffer`, spread it: `Address6.fromByteArray([...buf])`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1009)
+- `static fromUnsignedByteArray(bytes: any[]): Address6` — Convert an unsigned byte array to an Address6 object. To convert from a Node.js `Buffer`, spread it: `Address6.fromUnsignedByteArray([...buf])`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1019)
 
 **Instance methods**
 
@@ -198,20 +199,21 @@ Represents an IPv6 address
 - `inspectTeredo(): TeredoProperties` — Decodes the Teredo tunneling fields embedded in this address. Returns the Teredo prefix, server IPv4, client IPv4, raw flag bits, cone-NAT flag, UDP port, and Microsoft-format flag breakdown (reserved, universal/local, group/individual, nonce). Only meaningful for addresses in `2001::/32`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L794)
 - `inspect6to4(): SixToFourProperties` — Decodes the 6to4 tunneling fields embedded in this address. Returns the 6to4 prefix and the embedded IPv4 gateway address. Only meaningful for addresses in `2002::/16`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L857)
 - `to6to4(): Address6 | null` — Return a v6 6to4 address from a v6 v4inv6 address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L877)
-- `toByteArray(): number[]` — Return a byte array. To get a Node.js `Buffer`, wrap the result: `Buffer.from(address.toByteArray())`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L899)
-- `toUnsignedByteArray(): number[]` — Return an unsigned byte array. To get a Node.js `Buffer`, wrap the result: `Buffer.from(address.toUnsignedByteArray())`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L919)
-- `isCanonical(): boolean` — Returns true if the address is in the canonical form, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L970)
-- `isLinkLocal(): boolean` — Returns true if the address is a link local address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L978)
-- `isMulticast(): boolean` — Returns true if the address is a multicast address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L994)
-- `is4(): boolean` — Returns true if the address is a v4-in-v6 address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1002)
-- `isTeredo(): boolean` — Returns true if the address is a Teredo address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1010)
-- `is6to4(): boolean` — Returns true if the address is a 6to4 address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1018)
-- `isLoopback(): boolean` — Returns true if the address is a loopback address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1026)
-- `href(optionalPort?: string | number): string` — Returns the address as an HTTP URL with the host bracketed, e.g. `http://[2001:db8::1]/`. If `optionalPort` is provided it is appended, e.g. `http://[2001:db8::1]:8080/`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1037)
-- `link(options?: { className?: string; prefix?: string; v4?: boolean }): string` — Returns an HTML `<a>` element whose `href` encodes the address in a URL hash fragment (default prefix `/#address=`). Useful for linking between pages of an address-inspector UI. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1055)
-- `group(): string` — Groups an address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1095)
-- `regularExpressionString(this: Address6, substringSearch: boolean): string` — Generate a regular expression string that can be used to find or validate all variations of this address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1147)
-- `regularExpression(this: Address6, substringSearch: boolean): RegExp` — Generate a regular expression that can be used to find or validate all variations of this address. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1201)
+- `toAddress4Nat64(prefix: string): Address4 | null` — Extract the embedded IPv4 address from a NAT64 IPv6 address using the encoding defined by [RFC 6052](https://datatracker.ietf.org/doc/html/rfc6052). The default prefix is the well-known prefix `64:ff9b::/96`. Returns `null` if this address is not contained within the given prefix. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L944)
+- `toByteArray(): number[]` — Return a byte array. To get a Node.js `Buffer`, wrap the result: `Buffer.from(address.toByteArray())`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L979)
+- `toUnsignedByteArray(): number[]` — Return an unsigned byte array. To get a Node.js `Buffer`, wrap the result: `Buffer.from(address.toUnsignedByteArray())`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L999)
+- `isCanonical(): boolean` — Returns true if the address is in the canonical form, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1050)
+- `isLinkLocal(): boolean` — Returns true if the address is a link local address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1058)
+- `isMulticast(): boolean` — Returns true if the address is a multicast address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1074)
+- `is4(): boolean` — Returns true if the address is a v4-in-v6 address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1082)
+- `isTeredo(): boolean` — Returns true if the address is a Teredo address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1090)
+- `is6to4(): boolean` — Returns true if the address is a 6to4 address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1098)
+- `isLoopback(): boolean` — Returns true if the address is a loopback address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1106)
+- `href(optionalPort?: string | number): string` — Returns the address as an HTTP URL with the host bracketed, e.g. `http://[2001:db8::1]/`. If `optionalPort` is provided it is appended, e.g. `http://[2001:db8::1]:8080/`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1117)
+- `link(options?: { className?: string; prefix?: string; v4?: boolean }): string` — Returns an HTML `<a>` element whose `href` encodes the address in a URL hash fragment (default prefix `/#address=`). Useful for linking between pages of an address-inspector UI. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1135)
+- `group(): string` — Groups an address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1175)
+- `regularExpressionString(this: Address6, substringSearch: boolean): string` — Generate a regular expression string that can be used to find or validate all variations of this address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1227)
+- `regularExpression(this: Address6, substringSearch: boolean): RegExp` — Generate a regular expression that can be used to find or validate all variations of this address. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1281)
 
 **Properties**
 
@@ -229,8 +231,8 @@ Represents an IPv6 address
 - `subnetMask: number` — [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L109)
 - `v4: boolean` — [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L110)
 - `zone: string` — [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L111)
-- `isInSubnet: (this: Address4 | Address6, address: Address4 | Address6) => boolean` — Returns true if the given address is in the subnet of the current address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L958)
-- `isCorrect: (this: Address4 | Address6) => boolean` — Returns true if the address is correct, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L964)
+- `isInSubnet: (this: Address4 | Address6, address: Address4 | Address6) => boolean` — Returns true if the given address is in the subnet of the current address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1038)
+- `isCorrect: (this: Address4 | Address6) => boolean` — Returns true if the address is correct, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1044)
 
 <!-- API:END -->
 

--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -891,6 +891,86 @@ export class Address6 {
   }
 
   /**
+   * Embed an IPv4 address into a NAT64 IPv6 address using the encoding
+   * defined by [RFC 6052](https://datatracker.ietf.org/doc/html/rfc6052).
+   * The default prefix is the well-known prefix `64:ff9b::/96`. The prefix
+   * length must be one of 32, 40, 48, 56, 64, or 96; for prefixes shorter
+   * than /64 the IPv4 octets are split around the reserved bits 64–71.
+   * @example
+   * Address6.fromAddress4Nat64('192.0.2.33').correctForm(); // '64:ff9b::c000:221'
+   * Address6.fromAddress4Nat64('192.0.2.33', '2001:db8::/32').correctForm(); // '2001:db8:c000:221::'
+   */
+  static fromAddress4Nat64(address: string, prefix: string = '64:ff9b::/96'): Address6 {
+    const v4 = new Address4(address);
+    const prefix6 = new Address6(prefix);
+    const pl = prefix6.subnetMask;
+
+    if (pl !== 32 && pl !== 40 && pl !== 48 && pl !== 56 && pl !== 64 && pl !== 96) {
+      throw new AddressError('NAT64 prefix length must be 32, 40, 48, 56, 64, or 96');
+    }
+
+    const prefixBits = prefix6.binaryZeroPad();
+    const v4Bits = v4.binaryZeroPad();
+
+    let bits: string;
+    if (pl === 96) {
+      bits = prefixBits.slice(0, 96) + v4Bits;
+    } else {
+      const beforeU = 64 - pl;
+      bits =
+        prefixBits.slice(0, pl) +
+        v4Bits.slice(0, beforeU) +
+        '00000000' +
+        v4Bits.slice(beforeU) +
+        '0'.repeat(128 - 72 - (32 - beforeU));
+    }
+
+    const hex = BigInt(`0b${bits}`).toString(16).padStart(32, '0');
+    const groups: string[] = [];
+    for (let i = 0; i < 8; i++) {
+      groups.push(hex.slice(i * 4, (i + 1) * 4));
+    }
+    return new Address6(groups.join(':'));
+  }
+
+  /**
+   * Extract the embedded IPv4 address from a NAT64 IPv6 address using the
+   * encoding defined by [RFC 6052](https://datatracker.ietf.org/doc/html/rfc6052).
+   * The default prefix is the well-known prefix `64:ff9b::/96`. Returns
+   * `null` if this address is not contained within the given prefix.
+   * @example
+   * new Address6('64:ff9b::c000:221').toAddress4Nat64()!.correctForm(); // '192.0.2.33'
+   */
+  toAddress4Nat64(prefix: string = '64:ff9b::/96'): Address4 | null {
+    const prefix6 = new Address6(prefix);
+    const pl = prefix6.subnetMask;
+
+    if (pl !== 32 && pl !== 40 && pl !== 48 && pl !== 56 && pl !== 64 && pl !== 96) {
+      throw new AddressError('NAT64 prefix length must be 32, 40, 48, 56, 64, or 96');
+    }
+
+    if (!this.isInSubnet(prefix6)) {
+      return null;
+    }
+
+    const bits = this.binaryZeroPad();
+    let v4Bits: string;
+
+    if (pl === 96) {
+      v4Bits = bits.slice(96, 128);
+    } else {
+      const beforeU = 64 - pl;
+      v4Bits = bits.slice(pl, pl + beforeU) + bits.slice(72, 72 + (32 - beforeU));
+    }
+
+    const octets: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      octets.push(parseInt(v4Bits.slice(i * 8, (i + 1) * 8), 2).toString());
+    }
+    return new Address4(octets.join('.'));
+  }
+
+  /**
    * Return a byte array.
    *
    * To get a Node.js `Buffer`, wrap the result: `Buffer.from(address.toByteArray())`.

--- a/test/functionality-v6-test.ts
+++ b/test/functionality-v6-test.ts
@@ -349,6 +349,48 @@ describe('v6', () => {
     });
   });
 
+  describe('NAT64 (RFC 6052)', () => {
+    // Test vectors from RFC 6052 §2.4 (IPv4 192.0.2.33 across all prefix lengths).
+    const cases: Array<{ pl: number; prefix: string; encoded: string }> = [
+      { pl: 32, prefix: '2001:db8::/32', encoded: '2001:db8:c000:221::' },
+      { pl: 40, prefix: '2001:db8:100::/40', encoded: '2001:db8:1c0:2:21::' },
+      { pl: 48, prefix: '2001:db8:122::/48', encoded: '2001:db8:122:c000:2:2100::' },
+      { pl: 56, prefix: '2001:db8:122:300::/56', encoded: '2001:db8:122:3c0:0:221::' },
+      { pl: 64, prefix: '2001:db8:122:344::/64', encoded: '2001:db8:122:344:c0:2:2100:0' },
+      { pl: 96, prefix: '2001:db8:122:344::/96', encoded: '2001:db8:122:344::c000:221' },
+    ];
+
+    cases.forEach(({ pl, prefix, encoded }) => {
+      it(`encodes 192.0.2.33 with a /${pl} prefix`, () => {
+        Address6.fromAddress4Nat64('192.0.2.33', prefix).correctForm().should.equal(encoded);
+      });
+
+      it(`decodes ${encoded} with a /${pl} prefix`, () => {
+        const v4 = new Address6(encoded).toAddress4Nat64(prefix);
+        should.exist(v4);
+        v4!.correctForm().should.equal('192.0.2.33');
+      });
+    });
+
+    it('uses the well-known prefix 64:ff9b::/96 by default', () => {
+      Address6.fromAddress4Nat64('192.0.2.33').correctForm().should.equal('64:ff9b::c000:221');
+      new Address6('64:ff9b::c000:221').toAddress4Nat64()!.correctForm().should.equal('192.0.2.33');
+    });
+
+    it('encodes the example from issue #72', () => {
+      Address6.fromAddress4Nat64('127.0.0.1').correctForm().should.equal('64:ff9b::7f00:1');
+    });
+
+    it('returns null when decoding an address outside the prefix', () => {
+      expect(new Address6('2001:db8::1').toAddress4Nat64()).to.equal(null);
+    });
+
+    it('throws on an invalid prefix length', () => {
+      should.Throw(() => Address6.fromAddress4Nat64('192.0.2.33', '2001:db8::/80'));
+      should.Throw(() => new Address6('64:ff9b::1').toAddress4Nat64('2001:db8::/80'));
+    });
+  });
+
   describe('A different notation of the same address', () => {
     const addresses = notationsToAddresseses([
       '2001:db8:0:0:1:0:0:1/128',


### PR DESCRIPTION
## Summary

- Adds `Address6.fromAddress4Nat64(addressV4, prefix?)` to embed an IPv4 address into a NAT64 IPv6 address.
- Adds `Address6#toAddress4Nat64(prefix?)` to extract the embedded IPv4 from a NAT64 IPv6 address; returns `null` if the address is not in the given prefix.
- Supports all six [RFC 6052](https://datatracker.ietf.org/doc/html/rfc6052) prefix lengths: /32, /40, /48, /56, /64, /96. For prefixes shorter than /64 the IPv4 octets are split around the reserved bits 64–71 (the "u" octet).
- Defaults to the well-known prefix `64:ff9b::/96` so the common case is one-line: `Address6.fromAddress4Nat64('192.0.2.33').correctForm() // '64:ff9b::c000:221'`.

Closes #72.

## Test plan

- [x] RFC 6052 §2.4 test vectors for all six prefix lengths (encode + decode round-trip).
- [x] Default well-known prefix path covered.
- [x] `null` returned when decoding an address outside the prefix.
- [x] Throws on invalid prefix length (e.g. /80).
- [x] Full suite passes (3426 tests).