### PR TITLE
Add address-property predicates (private, ULA, loopback, link-local, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ link.isLinkLocal();                        // true
 link.isMulticast();                        // false
 link.isLoopback();                         // false
 
+new Address4('192.168.1.1').isPrivate();   // true (RFC 1918)
+new Address6('fc00::1').isULA();           // true (RFC 4193)
+
 // Numeric and byte representations
 v4.bigInt();                               // 3232235777n
 v4.toArray();                              // [192, 168, 1, 1]
@@ -66,7 +69,7 @@ Address6.fromURL('http://[2001:db8::1]:8080/').port;  // 8080
 - Parses all standard IPv4 and IPv6 notations, including subnets and zones
 - Parses IPv6 hosts (and ports) from URLs via `Address6.fromURL(url)`
 - Subnet membership checks (`isInSubnet`) and range queries (`startAddress` / `endAddress`)
-- Special-property checks: multicast, loopback, link-local, ULA, Teredo, 6to4, v4-in-v6
+- Special-property checks: private (RFC 1918) / ULA (RFC 4193), loopback, link-local, multicast, broadcast, unspecified, CGNAT, documentation, Teredo, 6to4, v4-in-v6
 - Decodes [Teredo](http://en.wikipedia.org/wiki/Teredo_tunneling#IPv6_addressing) and 6to4 tunneling information
 - Conversions: canonical/correct form, hex, binary, decimal, byte arrays, BigInt, `in-addr.arpa` / `ip6.arpa`
 - Runs in Node.js and the browser
@@ -137,8 +140,14 @@ Represents an IPv4 address
 - `getBitsBase2(start: number, end: number): string` — Returns the bits in the given range as a base-2 string [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L394)
 - `reverseForm(options?: ReverseFormOptions): string` — Return the reversed ip6.arpa form of the address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L404)
 - `isMulticast(): boolean` — Returns true if the given address is a multicast address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L428)
-- `binaryZeroPad(): string` — Returns a zero-padded base-2 string representation of the address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L436)
-- `groupForV6(): string` — Groups an IPv4 address for inclusion at the end of an IPv6 address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L447)
+- `isPrivate(): boolean` — Returns true if the address is in one of the [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) private address ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`). [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L436)
+- `isLoopback(): boolean` — Returns true if the address is in the loopback range `127.0.0.0/8` ([RFC 1122](https://datatracker.ietf.org/doc/html/rfc1122)). [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L444)
+- `isLinkLocal(): boolean` — Returns true if the address is in the link-local range `169.254.0.0/16` ([RFC 3927](https://datatracker.ietf.org/doc/html/rfc3927)). [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L452)
+- `isUnspecified(): boolean` — Returns true if the address is the unspecified address `0.0.0.0`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L460)
+- `isBroadcast(): boolean` — Returns true if the address is the limited broadcast address `255.255.255.255` ([RFC 919](https://datatracker.ietf.org/doc/html/rfc919)). [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L468)
+- `isCGNAT(): boolean` — Returns true if the address is in the carrier-grade NAT range `100.64.0.0/10` ([RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598)). [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L476)
+- `binaryZeroPad(): string` — Returns a zero-padded base-2 string representation of the address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L484)
+- `groupForV6(): string` — Groups an IPv4 address for inclusion at the end of an IPv6 address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv4.ts#L495)
 
 **Properties**
 
@@ -215,11 +224,14 @@ Represents an IPv6 address
 - `isTeredo(): boolean` — Returns true if the address is a Teredo address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1186)
 - `is6to4(): boolean` — Returns true if the address is a 6to4 address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1194)
 - `isLoopback(): boolean` — Returns true if the address is a loopback address, false otherwise [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1202)
-- `href(optionalPort?: string | number): string` — Returns the address as an HTTP URL with the host bracketed, e.g. `http://[2001:db8::1]/`. If `optionalPort` is provided it is appended, e.g. `http://[2001:db8::1]:8080/`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1213)
-- `link(options?: { className?: string; prefix?: string; v4?: boolean }): string` — Returns an HTML `<a>` element whose `href` encodes the address in a URL hash fragment (default prefix `/#address=`). Useful for linking between pages of an address-inspector UI. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1231)
-- `group(): string` — Groups an address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1271)
-- `regularExpressionString(this: Address6, substringSearch: boolean): string` — Generate a regular expression string that can be used to find or validate all variations of this address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1323)
-- `regularExpression(this: Address6, substringSearch: boolean): RegExp` — Generate a regular expression that can be used to find or validate all variations of this address. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1377)
+- `isULA(): boolean` — Returns true if the address is a Unique Local Address in `fc00::/7` ([RFC 4193](https://datatracker.ietf.org/doc/html/rfc4193)). ULAs are the IPv6 equivalent of IPv4 [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) private addresses. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1210)
+- `isUnspecified(): boolean` — Returns true if the address is the unspecified address `::`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1218)
+- `isDocumentation(): boolean` — Returns true if the address is in the documentation prefix `2001:db8::/32` ([RFC 3849](https://datatracker.ietf.org/doc/html/rfc3849)). [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1226)
+- `href(optionalPort?: string | number): string` — Returns the address as an HTTP URL with the host bracketed, e.g. `http://[2001:db8::1]/`. If `optionalPort` is provided it is appended, e.g. `http://[2001:db8::1]:8080/`. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1237)
+- `link(options?: { className?: string; prefix?: string; v4?: boolean }): string` — Returns an HTML `<a>` element whose `href` encodes the address in a URL hash fragment (default prefix `/#address=`). Useful for linking between pages of an address-inspector UI. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1255)
+- `group(): string` — Groups an address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1295)
+- `regularExpressionString(this: Address6, substringSearch: boolean): string` — Generate a regular expression string that can be used to find or validate all variations of this address [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1347)
+- `regularExpression(this: Address6, substringSearch: boolean): RegExp` — Generate a regular expression that can be used to find or validate all variations of this address. [src](https://github.com/beaugunderson/ip-address/blob/master/src/ipv6.ts#L1401)
 
 **Properties**
 

--- a/scripts/readme-template.md
+++ b/scripts/readme-template.md
@@ -46,6 +46,9 @@ link.isLinkLocal();                        // true
 link.isMulticast();                        // false
 link.isLoopback();                         // false
 
+new Address4('192.168.1.1').isPrivate();   // true (RFC 1918)
+new Address6('fc00::1').isULA();           // true (RFC 4193)
+
 // Numeric and byte representations
 v4.bigInt();                               // 3232235777n
 v4.toArray();                              // [192, 168, 1, 1]
@@ -66,7 +69,7 @@ Address6.fromURL('http://[2001:db8::1]:8080/').port;  // 8080
 - Parses all standard IPv4 and IPv6 notations, including subnets and zones
 - Parses IPv6 hosts (and ports) from URLs via `Address6.fromURL(url)`
 - Subnet membership checks (`isInSubnet`) and range queries (`startAddress` / `endAddress`)
-- Special-property checks: multicast, loopback, link-local, ULA, Teredo, 6to4, v4-in-v6
+- Special-property checks: private (RFC 1918) / ULA (RFC 4193), loopback, link-local, multicast, broadcast, unspecified, CGNAT, documentation, Teredo, 6to4, v4-in-v6
 - Decodes [Teredo](http://en.wikipedia.org/wiki/Teredo_tunneling#IPv6_addressing) and 6to4 tunneling information
 - Conversions: canonical/correct form, hex, binary, decimal, byte arrays, BigInt, `in-addr.arpa` / `ip6.arpa`
 - Runs in Node.js and the browser

--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -430,6 +430,54 @@ export class Address4 {
   }
 
   /**
+   * Returns true if the address is in one of the [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) private address ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`).
+   * @returns {boolean}
+   */
+  isPrivate(): boolean {
+    return PRIVATE_V4.some((subnet) => this.isInSubnet(subnet));
+  }
+
+  /**
+   * Returns true if the address is in the loopback range `127.0.0.0/8` ([RFC 1122](https://datatracker.ietf.org/doc/html/rfc1122)).
+   * @returns {boolean}
+   */
+  isLoopback(): boolean {
+    return this.isInSubnet(LOOPBACK_V4);
+  }
+
+  /**
+   * Returns true if the address is in the link-local range `169.254.0.0/16` ([RFC 3927](https://datatracker.ietf.org/doc/html/rfc3927)).
+   * @returns {boolean}
+   */
+  isLinkLocal(): boolean {
+    return this.isInSubnet(LINK_LOCAL_V4);
+  }
+
+  /**
+   * Returns true if the address is the unspecified address `0.0.0.0`.
+   * @returns {boolean}
+   */
+  isUnspecified(): boolean {
+    return this.isInSubnet(UNSPECIFIED_V4);
+  }
+
+  /**
+   * Returns true if the address is the limited broadcast address `255.255.255.255` ([RFC 919](https://datatracker.ietf.org/doc/html/rfc919)).
+   * @returns {boolean}
+   */
+  isBroadcast(): boolean {
+    return this.isInSubnet(BROADCAST_V4);
+  }
+
+  /**
+   * Returns true if the address is in the carrier-grade NAT range `100.64.0.0/10` ([RFC 6598](https://datatracker.ietf.org/doc/html/rfc6598)).
+   * @returns {boolean}
+   */
+  isCGNAT(): boolean {
+    return this.isInSubnet(CGNAT_V4);
+  }
+
+  /**
    * Returns a zero-padded base-2 string representation of the address
    * @returns {string}
    */
@@ -459,3 +507,13 @@ export class Address4 {
 }
 
 const MULTICAST_V4 = new Address4('224.0.0.0/4');
+const PRIVATE_V4 = [
+  new Address4('10.0.0.0/8'),
+  new Address4('172.16.0.0/12'),
+  new Address4('192.168.0.0/16'),
+];
+const LOOPBACK_V4 = new Address4('127.0.0.0/8');
+const LINK_LOCAL_V4 = new Address4('169.254.0.0/16');
+const UNSPECIFIED_V4 = new Address4('0.0.0.0/32');
+const BROADCAST_V4 = new Address4('255.255.255.255/32');
+const CGNAT_V4 = new Address4('100.64.0.0/10');

--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -1202,6 +1202,30 @@ export class Address6 {
   isLoopback(): boolean {
     return this.getType() === 'Loopback';
   }
+
+  /**
+   * Returns true if the address is a Unique Local Address in `fc00::/7` ([RFC 4193](https://datatracker.ietf.org/doc/html/rfc4193)). ULAs are the IPv6 equivalent of IPv4 [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) private addresses.
+   * @returns {boolean}
+   */
+  isULA(): boolean {
+    return this.isInSubnet(ULA_SUBNET);
+  }
+
+  /**
+   * Returns true if the address is the unspecified address `::`.
+   * @returns {boolean}
+   */
+  isUnspecified(): boolean {
+    return this.getType() === 'Unspecified';
+  }
+
+  /**
+   * Returns true if the address is in the documentation prefix `2001:db8::/32` ([RFC 3849](https://datatracker.ietf.org/doc/html/rfc3849)).
+   * @returns {boolean}
+   */
+  isDocumentation(): boolean {
+    return this.isInSubnet(DOCUMENTATION_SUBNET);
+  }
   // #endregion
 
   // #region HTML
@@ -1386,3 +1410,5 @@ const TYPE_SUBNETS: Array<[Address6, string]> = Object.keys(constants6.TYPES).ma
 ]);
 const TEREDO_SUBNET = new Address6('2001::/32');
 const SIX_TO_FOUR_SUBNET = new Address6('2002::/16');
+const ULA_SUBNET = new Address6('fc00::/7');
+const DOCUMENTATION_SUBNET = new Address6('2001:db8::/32');

--- a/test/functionality-v4-test.ts
+++ b/test/functionality-v4-test.ts
@@ -486,4 +486,101 @@ describe('v4', () => {
       });
     });
   });
+
+  describe('isPrivate', () => {
+    it('detects RFC 1918 ranges', () => {
+      notationsToAddresseses([
+        '10.0.0.0',
+        '10.255.255.255',
+        '172.16.0.0',
+        '172.16.0.1',
+        '172.31.255.255',
+        '192.168.0.0',
+        '192.168.1.1',
+        '192.168.255.255',
+      ]).forEach((topic) => {
+        should.equal(topic.isPrivate(), true);
+      });
+    });
+
+    it('rejects non-private addresses including range boundaries', () => {
+      notationsToAddresseses([
+        '8.8.8.8',
+        '9.255.255.255',
+        '11.0.0.0',
+        '172.15.255.255',
+        '172.32.0.0',
+        '192.167.255.255',
+        '192.169.0.0',
+      ]).forEach((topic) => {
+        should.equal(topic.isPrivate(), false);
+      });
+    });
+  });
+
+  describe('isLoopback', () => {
+    it('detects 127.0.0.0/8', () => {
+      notationsToAddresseses(['127.0.0.0', '127.0.0.1', '127.255.255.255']).forEach((topic) => {
+        should.equal(topic.isLoopback(), true);
+      });
+    });
+
+    it('rejects non-loopback addresses', () => {
+      notationsToAddresseses(['126.255.255.255', '128.0.0.0', '8.8.8.8']).forEach((topic) => {
+        should.equal(topic.isLoopback(), false);
+      });
+    });
+  });
+
+  describe('isLinkLocal', () => {
+    it('detects 169.254.0.0/16', () => {
+      notationsToAddresseses(['169.254.0.0', '169.254.1.1', '169.254.255.255']).forEach((topic) => {
+        should.equal(topic.isLinkLocal(), true);
+      });
+    });
+
+    it('rejects addresses outside 169.254.0.0/16', () => {
+      notationsToAddresseses(['169.253.255.255', '169.255.0.0', '8.8.8.8']).forEach((topic) => {
+        should.equal(topic.isLinkLocal(), false);
+      });
+    });
+  });
+
+  describe('isUnspecified', () => {
+    it('detects 0.0.0.0', () => {
+      should.equal(new Address4('0.0.0.0').isUnspecified(), true);
+    });
+
+    it('rejects non-zero addresses', () => {
+      notationsToAddresseses(['0.0.0.1', '1.0.0.0', '8.8.8.8']).forEach((topic) => {
+        should.equal(topic.isUnspecified(), false);
+      });
+    });
+  });
+
+  describe('isBroadcast', () => {
+    it('detects 255.255.255.255', () => {
+      should.equal(new Address4('255.255.255.255').isBroadcast(), true);
+    });
+
+    it('rejects non-broadcast addresses including subnet broadcasts', () => {
+      notationsToAddresseses(['255.255.255.254', '192.168.1.255', '8.8.8.8']).forEach((topic) => {
+        should.equal(topic.isBroadcast(), false);
+      });
+    });
+  });
+
+  describe('isCGNAT', () => {
+    it('detects 100.64.0.0/10', () => {
+      notationsToAddresseses(['100.64.0.0', '100.64.0.1', '100.127.255.255']).forEach((topic) => {
+        should.equal(topic.isCGNAT(), true);
+      });
+    });
+
+    it('rejects addresses outside 100.64.0.0/10', () => {
+      notationsToAddresseses(['100.63.255.255', '100.128.0.0', '8.8.8.8']).forEach((topic) => {
+        should.equal(topic.isCGNAT(), false);
+      });
+    });
+  });
 });

--- a/test/functionality-v6-test.ts
+++ b/test/functionality-v6-test.ts
@@ -871,6 +871,69 @@ describe('v6', () => {
     });
   });
 
+  describe('isULA', () => {
+    it('detects fc00::/7', () => {
+      notationsToAddresseses([
+        'fc00::',
+        'fc00::1',
+        'fcff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+        'fd00::',
+        'fd12:3456:789a::1',
+        'fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+      ]).forEach((topic) => {
+        should.equal(topic.isULA(), true);
+      });
+    });
+
+    it('rejects addresses outside fc00::/7 including fe80::/10 and global unicast', () => {
+      notationsToAddresseses([
+        '::',
+        '::1',
+        'fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+        'fe00::',
+        'fe80::1',
+        '2001:db8::1',
+      ]).forEach((topic) => {
+        should.equal(topic.isULA(), false);
+      });
+    });
+  });
+
+  describe('isUnspecified', () => {
+    it('detects ::', () => {
+      should.equal(new Address6('::').isUnspecified(), true);
+    });
+
+    it('rejects non-zero addresses', () => {
+      notationsToAddresseses(['::1', '2001:db8::1', 'fc00::']).forEach((topic) => {
+        should.equal(topic.isUnspecified(), false);
+      });
+    });
+  });
+
+  describe('isDocumentation', () => {
+    it('detects 2001:db8::/32', () => {
+      notationsToAddresseses([
+        '2001:db8::',
+        '2001:db8::1',
+        '2001:db8:ffff:ffff:ffff:ffff:ffff:ffff',
+      ]).forEach((topic) => {
+        should.equal(topic.isDocumentation(), true);
+      });
+    });
+
+    it('rejects addresses outside 2001:db8::/32', () => {
+      notationsToAddresseses([
+        '2001:db7:ffff:ffff:ffff:ffff:ffff:ffff',
+        '2001:db9::',
+        '2001::1',
+        'fc00::',
+      ]).forEach((topic) => {
+        should.equal(topic.isDocumentation(), false);
+      });
+    });
+  });
+
   describe('String helpers', () => {
     describe('spanLeadingZeroes', () => {
       it('should span leading zeroes', () => {


### PR DESCRIPTION
## Summary

Closes #53. Closes #54.

Adds the property checks #53 asked for (`isPrivate` + ULA detection) plus the rest of the same family in one sweep — including `Address4.isLoopback()` for `127.0.0.0/8`, which is exactly what #54 requested.

**`Address4`** — `isPrivate()` (RFC 1918), `isLoopback()` (`127.0.0.0/8`), `isLinkLocal()` (`169.254.0.0/16`, RFC 3927), `isUnspecified()` (`0.0.0.0`), `isBroadcast()` (`255.255.255.255`, RFC 919), `isCGNAT()` (`100.64.0.0/10`, RFC 6598).

**`Address6`** — `isULA()` (`fc00::/7`, RFC 4193), `isUnspecified()` (`::`), `isDocumentation()` (`2001:db8::/32`, RFC 3849).

The README's features line previously claimed ULA support but no `isULA()` existed; this PR makes that claim true and broadens it to cover the full set.

Test coverage hits positive matches, adjacent non-matches, and range boundaries (e.g. `172.15.255.255` / `172.32.0.0` for the `/12`, `100.63.255.255` / `100.128.0.0` for the `/10`, `fbff:…` / `fe00::` around `fc00::/7`, `126.255.255.255` / `128.0.0.0` around `127.0.0.0/8`).

## Test plan

- [x] `npm test` — all 3486 tests pass (including the new ones)
- [x] `npx tsc --noEmit` clean
- [x] `npm run docs` regenerates the API section with the new methods