### PR TITLE
Validate static factories instead of silently overflowing

### DIFF
--- a/src/ipv4.ts
+++ b/src/ipv4.ts
@@ -166,31 +166,41 @@ export class Address4 {
   }
 
   /**
-   * Converts a hex string to an IPv4 address object
+   * Converts a hex string to an IPv4 address object. Accepts 8 hex digits
+   * with optional `:` separators (e.g. `'7f000001'` or `'7f:00:00:01'`).
+   * Throws `AddressError` for any other length or for non-hex characters.
    * @param {string} hex - a hex string to convert
    * @returns {Address4}
    */
   static fromHex(hex: string): Address4 {
-    const padded = hex.replace(/:/g, '').padStart(8, '0');
+    const stripped = hex.replace(/:/g, '');
+
+    if (!/^[0-9a-fA-F]{8}$/.test(stripped)) {
+      throw new AddressError('IPv4 hex must be exactly 8 hex digits');
+    }
+
     const groups = [];
-    let i;
 
-    for (i = 0; i < 8; i += 2) {
-      const h = padded.slice(i, i + 2);
-
-      groups.push(parseInt(h, 16));
+    for (let i = 0; i < 8; i += 2) {
+      groups.push(parseInt(stripped.slice(i, i + 2), 16));
     }
 
     return new Address4(groups.join('.'));
   }
 
   /**
-   * Converts an integer into a IPv4 address object
+   * Converts an integer into a IPv4 address object. The integer must be a
+   * non-negative safe integer in the range `[0, 2**32 - 1]`; otherwise
+   * `AddressError` is thrown.
    * @param {integer} integer - a number to convert
    * @returns {Address4}
    */
   static fromInteger(integer: number): Address4 {
-    return Address4.fromHex(integer.toString(16));
+    if (!Number.isInteger(integer) || integer < 0 || integer > 0xffffffff) {
+      throw new AddressError('IPv4 integer must be in the range 0 to 2**32 - 1');
+    }
+
+    return Address4.fromHex(integer.toString(16).padStart(8, '0'));
   }
 
   /**
@@ -343,12 +353,17 @@ export class Address4 {
   }
 
   /**
-   * Converts a BigInt to a v4 address object
+   * Converts a BigInt to a v4 address object. The value must be in the
+   * range `[0, 2**32 - 1]`; otherwise `AddressError` is thrown.
    * @param {bigint} bigInt - a BigInt to convert
    * @returns {Address4}
    */
   static fromBigInt(bigInt: bigint): Address4 {
-    return Address4.fromHex(bigInt.toString(16));
+    if (bigInt < 0n || bigInt > 0xffffffffn) {
+      throw new AddressError('IPv4 BigInt must be in the range 0 to 2**32 - 1');
+    }
+
+    return Address4.fromHex(bigInt.toString(16).padStart(8, '0'));
   }
 
   /**

--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -172,7 +172,8 @@ export class Address6 {
   }
 
   /**
-   * Convert a BigInt to a v6 address object
+   * Convert a BigInt to a v6 address object. The value must be in the
+   * range `[0, 2**128 - 1]`; otherwise `AddressError` is thrown.
    * @param {bigint} bigInt - a BigInt to convert
    * @returns {Address6}
    * @example
@@ -181,11 +182,14 @@ export class Address6 {
    * address.correctForm(); // '::e8:d4a5:1000'
    */
   static fromBigInt(bigInt: bigint): Address6 {
+    if (bigInt < 0n || bigInt > (1n << BigInt(constants6.BITS)) - 1n) {
+      throw new AddressError('IPv6 BigInt must be in the range 0 to 2**128 - 1');
+    }
+
     const hex = bigInt.toString(16).padStart(32, '0');
     const groups = [];
-    let i;
 
-    for (i = 0; i < constants6.GROUPS; i++) {
+    for (let i = 0; i < constants6.GROUPS; i++) {
       groups.push(hex.slice(i * 4, (i + 1) * 4));
     }
 
@@ -890,7 +894,9 @@ export class Address6 {
   to4(): Address4 {
     const binary = this.binaryZeroPad().split('');
 
-    return Address4.fromHex(BigInt(`0b${binary.slice(96, 128).join('')}`).toString(16));
+    return Address4.fromHex(
+      BigInt(`0b${binary.slice(96, 128).join('')}`).toString(16).padStart(8, '0'),
+    );
   }
 
   /**
@@ -950,7 +956,9 @@ export class Address6 {
 
     const bitsForClient4 = this.getBits(96, 128);
     // eslint-disable-next-line no-bitwise
-    const client4 = Address4.fromHex((bitsForClient4 ^ BigInt('0xffffffff')).toString(16));
+    const client4 = Address4.fromHex(
+      (bitsForClient4 ^ BigInt('0xffffffff')).toString(16).padStart(8, '0'),
+    );
 
     const flagsBase2 = this.getBitsBase2(64, 80);
 

--- a/test/functionality-v4-test.ts
+++ b/test/functionality-v4-test.ts
@@ -357,6 +357,46 @@ describe('v4', () => {
     it('should parse correctly', () => {
       topic.correctForm().should.equal('127.0.0.1');
     });
+
+    it('should accept the boundary values 0 and 2**32 - 1', () => {
+      Address4.fromBigInt(0n).correctForm().should.equal('0.0.0.0');
+      Address4.fromBigInt(0xffffffffn).correctForm().should.equal('255.255.255.255');
+    });
+
+    it('should reject negative values', () => {
+      (() => Address4.fromBigInt(-1n)).should.throw(
+        'IPv4 BigInt must be in the range 0 to 2**32 - 1',
+      );
+    });
+
+    it('should reject values greater than 2**32 - 1', () => {
+      (() => Address4.fromBigInt(0x100000000n)).should.throw(
+        'IPv4 BigInt must be in the range 0 to 2**32 - 1',
+      );
+    });
+  });
+
+  describe('Creating an address from an integer', () => {
+    it('should reject negative integers', () => {
+      (() => Address4.fromInteger(-1)).should.throw(
+        'IPv4 integer must be in the range 0 to 2**32 - 1',
+      );
+    });
+
+    it('should reject integers greater than 2**32 - 1', () => {
+      (() => Address4.fromInteger(2 ** 32)).should.throw(
+        'IPv4 integer must be in the range 0 to 2**32 - 1',
+      );
+    });
+
+    it('should reject non-integer numbers', () => {
+      (() => Address4.fromInteger(1.5)).should.throw(
+        'IPv4 integer must be in the range 0 to 2**32 - 1',
+      );
+      (() => Address4.fromInteger(NaN)).should.throw(
+        'IPv4 integer must be in the range 0 to 2**32 - 1',
+      );
+    });
   });
 
   describe('Converting an address to a BigInt', () => {
@@ -372,6 +412,28 @@ describe('v4', () => {
 
     it('should parse correctly', () => {
       topic.correctForm().should.equal('127.0.0.1');
+    });
+
+    it('should accept 8 hex digits without separators', () => {
+      Address4.fromHex('7f000001').correctForm().should.equal('127.0.0.1');
+    });
+
+    it('should reject hex strings shorter than 8 digits', () => {
+      (() => Address4.fromHex('ff:ff')).should.throw(
+        'IPv4 hex must be exactly 8 hex digits',
+      );
+    });
+
+    it('should reject hex strings longer than 8 digits', () => {
+      (() => Address4.fromHex('1ff:ff:ff:ff')).should.throw(
+        'IPv4 hex must be exactly 8 hex digits',
+      );
+    });
+
+    it('should reject non-hex characters', () => {
+      (() => Address4.fromHex('zz:zz:zz:zz')).should.throw(
+        'IPv4 hex must be exactly 8 hex digits',
+      );
     });
   });
 

--- a/test/functionality-v6-test.ts
+++ b/test/functionality-v6-test.ts
@@ -638,6 +638,26 @@ describe('v6', () => {
     it('should parse correctly', () => {
       should.equal(topic.correctForm(), 'a:b:c:d:e:f:0:1');
     });
+
+    it('should accept the boundary values 0 and 2**128 - 1', () => {
+      should.equal(Address6.fromBigInt(0n).correctForm(), '::');
+      should.equal(
+        Address6.fromBigInt((1n << 128n) - 1n).correctForm(),
+        'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+      );
+    });
+
+    it('should reject negative values', () => {
+      (() => Address6.fromBigInt(-1n)).should.throw(
+        'IPv6 BigInt must be in the range 0 to 2**128 - 1',
+      );
+    });
+
+    it('should reject values greater than 2**128 - 1', () => {
+      (() => Address6.fromBigInt(1n << 128n)).should.throw(
+        'IPv6 BigInt must be in the range 0 to 2**128 - 1',
+      );
+    });
   });
 
   describe('subnetMaskAddress', () => {


### PR DESCRIPTION
## Summary

Closes #69. Several static factories previously masked invalid input and produced surprising addresses; they now throw `AddressError` with their own messages.

- `Address4.fromBigInt` and `Address6.fromBigInt` reject negatives and values above `2**32 - 1` / `2**128 - 1` (previously silently truncated, e.g. `Address6.fromBigInt(2n ** 128n)` returned `1000:0000:...`)
- `Address4.fromHex` requires exactly 8 hex digits (with optional `:` separators) and rejects non-hex characters (previously `'ff:ff'` returned `0.0.255.255` and over-long input dropped its high digits)
- `Address4.fromInteger` validates `Number.isInteger` and the `[0, 2**32-1]` range (previously `NaN` returned `0.0.0.10` and `2 ** 32` overflowed to `16.0.0.0`)
- The two internal `Address4.fromHex` callers in `ipv6.ts` (`to4()` and `inspectTeredo()`) pad their hex strings explicitly since `fromHex` no longer zero-fills short input

## Test plan

- [x] `npm test` — 3526 passing, including 13 new tests covering negative / overflow / wrong-length / non-numeric inputs for each factory
- [x] `npm run build` — clean tsc compile
- [x] Verified `to4()` still returns `1.0.0.127` for `::1.0.0.127` (regression check for the internal-caller padding change)