### PR TITLE
Fix repository URL protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/beaugunderson/ip-address.git"
+    "url": "https://github.com/beaugunderson/ip-address.git"
   },
   "overrides": {
     "diff": "^8.0.3",


### PR DESCRIPTION
This updates the package metadata repository URL from the legacy `git://` protocol to HTTPS.

The `git://` protocol is unauthenticated and may be blocked on some networks, while the HTTPS GitHub URL is directly accessible to npm users and tooling.

Validation:
- Parsed `package.json` and asserted `repository.url`
- `git diff --check`
- `npm install --ignore-scripts`
- `npm test`