### PR TITLE
fix: pad Address6#toByteArray to a full 16 bytes

### DIFF
--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -1122,10 +1122,7 @@ export class Address6 {
    * @returns {Array}
    */
   toByteArray(): number[] {
-    const valueWithoutPadding = this.bigInt().toString(16);
-    const leadingPad = '0'.repeat(valueWithoutPadding.length % 2);
-
-    const value = `${leadingPad}${valueWithoutPadding}`;
+    const value = this.bigInt().toString(16).padStart(constants6.BITS / 4, '0');
 
     const bytes = [];
     for (let i = 0, length = value.length; i < length; i += 2) {

--- a/test/address-test.ts
+++ b/test/address-test.ts
@@ -90,7 +90,7 @@ function addressIs(addressString: string, descriptors: string[]) {
         it('converts to a byte array and back', () => {
           const byteArray = address6.toByteArray();
 
-          byteArray.length.should.be.at.most(16);
+          byteArray.length.should.equal(16);
 
           const converted = Address6.fromByteArray(byteArray);
 
@@ -100,7 +100,7 @@ function addressIs(addressString: string, descriptors: string[]) {
         it('converts to an unsigned byte array and back', () => {
           const byteArray = address6.toUnsignedByteArray();
 
-          byteArray.length.should.be.at.most(16);
+          byteArray.length.should.equal(16);
 
           const converted = Address6.fromUnsignedByteArray(byteArray);
 

--- a/test/functionality-v6-test.ts
+++ b/test/functionality-v6-test.ts
@@ -1241,4 +1241,26 @@ describe('v6', () => {
       });
     });
   });
+
+  describe('toByteArray', () => {
+    it('always returns 16 bytes, including for addresses with leading zero bytes', () => {
+      // RFC 4291 section 2: an IPv6 address is a 128-bit (16-octet) identifier,
+      // so its byte array must always be 16 bytes long.
+      new Address6('::').toByteArray().length.should.equal(16);
+      new Address6('::1').toByteArray().length.should.equal(16);
+      new Address6('::ffff:192.168.0.1').toByteArray().length.should.equal(16);
+      new Address6('64:ff9b::c000:221').toByteArray().length.should.equal(16);
+      new Address6('a:b:c:d:e:f:0:1').toByteArray().length.should.equal(16);
+      new Address6('::1').toUnsignedByteArray().length.should.equal(16);
+    });
+
+    it('preserves the high-order zero bytes', () => {
+      new Address6('::1')
+        .toByteArray()
+        .should.deep.equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+      new Address6('::ffff:192.168.0.1')
+        .toByteArray()
+        .should.deep.equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 168, 0, 1]);
+    });
+  });
 });


### PR DESCRIPTION
An IPv6 address is a 128-bit (16-octet) identifier per RFC 4291 §2, but `Address6#toByteArray()` and `toUnsignedByteArray()` return a **variable-length** array that drops high-order zero bytes:

```js
new Address6("::1").toByteArray()                // [1]                      (expected 16 bytes)
new Address6("::").toByteArray()                 // [0]                      (expected 16 bytes)
new Address6("::ffff:192.168.0.1").toByteArray() // [255,255,192,168,0,1]    (expected 16 bytes)
```

The documented use is `Buffer.from(address.toByteArray())`, so for `::1` you get a 1-byte buffer instead of the 16-byte address. This breaks fixed-width consumers: socket/packet builders, DB `BINARY(16)`/`inet` columns (cf. #23), dedup/ACL byte comparisons, and any pre-sized buffer. It affects roughly half of all addresses (anything with a zero top byte: loopback, unspecified, link-local `fe80::`, ULA, documentation `2001:db8::`, IPv4-mapped, NAT64).

### Cause
`bigInt().toString(16)` drops leading zero nibbles. The existing `leadingPad` only restores odd-nibble parity (the fix for the length-17 case in #40), never whole zero bytes.

### Fix
Pad the hex to `BITS / 4` (32) nibbles, mirroring the existing `binaryZeroPad()` (`toString(2).padStart(BITS, "0")`) and the `Address4#toArray` sibling, which already returns a fixed-width array. `fromByteArray`/`fromUnsignedByteArray` already read big-endian, so round-tripping is unchanged.

### Tests
Strengthened the existing round-trip assertions from `length.should.be.at.most(16)` to `equal(16)`, and added focused cases for leading-zero addresses (`::`, `::1`, `::ffff:192.168.0.1`). These fail on the current code and pass with the fix; full suite green.
