### PR TITLE
fix: Address6.fromURL lets port 65536 through as valid

### DIFF
--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -246,8 +246,8 @@ export class Address6 {
     if (port) {
       port = parseInt(port, 10);
 
-      // squelch out of range ports
-      if (port < 0 || port > 65536) {
+      // squelch out of range ports (valid ports are 0-65535)
+      if (port < 0 || port > 65535) {
         port = null;
       }
     } else {

--- a/test/functionality-v6-test.ts
+++ b/test/functionality-v6-test.ts
@@ -608,11 +608,18 @@ describe('v6', () => {
       expect(obj.port).to.equal(80);
     });
 
-    it('should work with a URL with a long port number', () => {
+    it('should work with the highest valid port number', () => {
+      const obj = Address6.fromURL('http://[2001:db8::5]:65535/foo');
+
+      expect(obj.address?.address).to.equal('2001:db8::5');
+      expect(obj.port).to.equal(65535);
+    });
+
+    it('should parse the address but fail with a port number one past the valid range', () => {
       const obj = Address6.fromURL('http://[2001:db8::5]:65536/foo');
 
       expect(obj.address?.address).to.equal('2001:db8::5');
-      expect(obj.port).to.equal(65536);
+      expect(obj.port).to.equal(null);
     });
 
     it('should work with a address with a port', () => {
@@ -622,11 +629,11 @@ describe('v6', () => {
       expect(obj.port).to.equal(80);
     });
 
-    it('should work with an address with a long port', () => {
+    it('should parse the address but fail with an out of range port', () => {
       const obj = Address6.fromURL('[2001:db8::5]:65536');
 
       expect(obj.address?.address).to.equal('2001:db8::5');
-      expect(obj.port).to.equal(65536);
+      expect(obj.port).to.equal(null);
     });
 
     it('should parse the address but fail with an invalid port', () => {


### PR DESCRIPTION
Noticed `fromURL` treats 65536 as an in-range port when it's actually one past the max (valid ports are 0-65535, it's a 16-bit field). So `[::1]:65536` comes back with `port: 65536` instead of being squelched to `null` like every other out-of-range value. Looks like a straight off-by-one that's been sitting there since the original commit.

Fixed the bound and updated the two existing tests that were asserting the wrong value, plus added one that pins 65535 as the actual ceiling.