### PR TITLE
Validate byte arrays in Address6.fromByteArray/fromUnsignedByteArray

### DIFF
--- a/src/ipv6.ts
+++ b/src/ipv6.ts
@@ -1159,8 +1159,19 @@ export class Address6 {
    * To convert from a Node.js `Buffer`, spread it: `Address6.fromByteArray([...buf])`.
    * @returns {Address6}
    */
-  static fromByteArray(bytes: Array<any>): Address6 {
-    return this.fromUnsignedByteArray(bytes.map(unsignByte));
+  static fromByteArray(bytes: Array<number>): Address6 {
+    if (bytes.length !== 16) {
+      throw new AddressError('IPv6 addresses require exactly 16 bytes');
+    }
+
+    // Validate that all bytes are within valid range (0-255)
+    for (let i = 0; i < bytes.length; i++) {
+      if (!Number.isInteger(bytes[i]) || bytes[i] < 0 || bytes[i] > 255) {
+        throw new AddressError('All bytes must be integers between 0 and 255');
+      }
+    }
+
+    return this.fromUnsignedByteArray(bytes);
   }
 
   /**
@@ -1169,7 +1180,18 @@ export class Address6 {
    * To convert from a Node.js `Buffer`, spread it: `Address6.fromUnsignedByteArray([...buf])`.
    * @returns {Address6}
    */
-  static fromUnsignedByteArray(bytes: Array<any>): Address6 {
+  static fromUnsignedByteArray(bytes: Array<number>): Address6 {
+    if (bytes.length !== 16) {
+      throw new AddressError('IPv6 addresses require exactly 16 bytes');
+    }
+
+    // Validate that all bytes are within valid range (0-255)
+    for (let i = 0; i < bytes.length; i++) {
+      if (!Number.isInteger(bytes[i]) || bytes[i] < 0 || bytes[i] > 255) {
+        throw new AddressError('All bytes must be integers between 0 and 255');
+      }
+    }
+
     const BYTE_MAX = BigInt('256');
     let result = BigInt('0');
     let multiplier = BigInt('1');

--- a/test/functionality-v6-test.ts
+++ b/test/functionality-v6-test.ts
@@ -1539,6 +1539,102 @@ describe('v6', () => {
     });
   });
 
+  describe('Creating an address from a byte array', () => {
+    const valid = [32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+
+    it('should parse correctly from a valid 16-byte array', () => {
+      Address6.fromByteArray(valid).correctForm().should.equal('2001:db8::1');
+      Address6.fromByteArray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+        .correctForm()
+        .should.equal('::1');
+    });
+
+    it('should round-trip through toByteArray', () => {
+      const topic = new Address6('2001:db8::1');
+      Address6.fromByteArray(topic.toByteArray()).correctForm().should.equal(topic.correctForm());
+    });
+
+    it('should throw for arrays that are not exactly 16 bytes', () => {
+      // RFC 4291 section 2: an IPv6 address is exactly 16 octets.
+      should.Throw(() => Address6.fromByteArray([]), 'IPv6 addresses require exactly 16 bytes');
+      should.Throw(
+        () => Address6.fromByteArray([1, 2, 3]),
+        'IPv6 addresses require exactly 16 bytes',
+      );
+      // 17 bytes with a leading zero has the same magnitude as the 16-byte
+      // value, so a result-only bounds check on the BigInt never catches it.
+      should.Throw(
+        () => Address6.fromByteArray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+        'IPv6 addresses require exactly 16 bytes',
+      );
+    });
+
+    it('should throw for out-of-range bytes', () => {
+      // 300 in the low byte does not overflow 2**128-1, so fromBigInt accepted it.
+      should.Throw(
+        () => Address6.fromByteArray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 300]),
+        'All bytes must be integers between 0 and 255',
+      );
+      // A high out-of-range byte does overflow; it is now rejected per-byte first.
+      should.Throw(
+        () => Address6.fromByteArray([300, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        'All bytes must be integers between 0 and 255',
+      );
+      should.Throw(
+        () => Address6.fromByteArray([-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        'All bytes must be integers between 0 and 255',
+      );
+    });
+
+    it('should throw for non-integer bytes', () => {
+      should.Throw(
+        () => Address6.fromByteArray([1.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        'All bytes must be integers between 0 and 255',
+      );
+    });
+  });
+
+  describe('Creating an address from an unsigned byte array', () => {
+    const valid = [32, 1, 13, 184, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+
+    it('should parse correctly from a valid 16-byte array', () => {
+      Address6.fromUnsignedByteArray(valid).correctForm().should.equal('2001:db8::1');
+    });
+
+    it('should throw for arrays that are not exactly 16 bytes', () => {
+      should.Throw(
+        () => Address6.fromUnsignedByteArray([]),
+        'IPv6 addresses require exactly 16 bytes',
+      );
+      should.Throw(
+        () => Address6.fromUnsignedByteArray([1, 2, 3]),
+        'IPv6 addresses require exactly 16 bytes',
+      );
+      should.Throw(
+        () => Address6.fromUnsignedByteArray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+        'IPv6 addresses require exactly 16 bytes',
+      );
+    });
+
+    it('should throw for out-of-range bytes', () => {
+      should.Throw(
+        () => Address6.fromUnsignedByteArray([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 300]),
+        'All bytes must be integers between 0 and 255',
+      );
+      should.Throw(
+        () => Address6.fromUnsignedByteArray([-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        'All bytes must be integers between 0 and 255',
+      );
+    });
+
+    it('should throw for non-integer bytes', () => {
+      should.Throw(
+        () => Address6.fromUnsignedByteArray([1.5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        'All bytes must be integers between 0 and 255',
+      );
+    });
+  });
+
   describe('an address with more than one subnet suffix', () => {
     // RE_SUBNET_STRING anchors on the end of the address, so it strips only
     // the trailing suffix. Anything left over is malformed and must be


### PR DESCRIPTION
`Address4.fromByteArray` (added in #180 "for API consistency with Address6") and the static factories hardened in #201 reject wrong-length, out-of-range, and non-integer input. The `Address6` equivalents validate nothing — they fold the array straight into a BigInt and only bounds-check the aggregate result in `fromBigInt` — so every analogous bad input silently produces a bogus address instead of throwing:

```js
Address6.fromByteArray([1, 2, 3])                            // -> ::1:203  (3 bytes)
Address6.fromByteArray([0, 0, ...fourteen zeros, 1])         // -> ::1      (17 bytes)
Address6.fromUnsignedByteArray([...Array(15).fill(0), 300])  // -> ::12c    (byte > 255)
Address6.fromByteArray([1.5, ...Array(15).fill(0)])          // -> 100::    (non-integer)
```

`Address4` rejects all four. The 17-byte case shows why the existing `fromBigInt` result-bound can't cover this: a leading zero byte keeps the magnitude under 2**128, so only a length check catches it.

Both `Address6` methods now apply the same guards as `Address4`: exactly 16 bytes, each an integer in 0-255 (RFC 4291 §2), throwing `AddressError` otherwise. The existing round-trip tests still pass because `toByteArray()` only ever emits 0-255. Added a regression matrix over both methods × length/range/integer, with valid 16-byte controls.

`npx mocha`: 3580 passing (was 3571).
